### PR TITLE
Only disable/enable repos that should be

### DIFF
--- a/roles/rhsm/tasks/main.yml
+++ b/roles/rhsm/tasks/main.yml
@@ -7,10 +7,15 @@
     password: "{{ rhsm_password }}"
     pool: "{{ rhsm_pool }}" 
 
-- name: "Disable all repositories"
-  shell: 'subscription-manager repos --disable="*"'
+- name: "Obtain currently enabled repos"
+  shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
+  register: enabled_repos
 
-- name: "Enable specified repositories"
+- name: "Disable repositories that should not be enabled"
+  shell: "subscription-manager repos --disable={{ item }}"
+  with_items: "{{ enabled_repos.stdout_lines | difference(rhsm_repos) }}"
+
+- name: "Enable specified repositories not already enabled"
   command: "subscription-manager repos --enable={{ item }}"
-  with_items: "{{ rhsm_repos }}"
+  with_items: "{{ rhsm_repos | difference(enabled_repos.stdout_lines) }}"
 


### PR DESCRIPTION
### What does this PR do?
This change implements disabling/enabling deltas in the repos list - i.e.: only disable repos that should stay enabled and only enable repos that aren't already enabled

### How should this be tested?
Run with an inventory where the `rhsm_repos` list is set to a few repos. After a successful run and the correct repos have been enabled, re-run with a change in the list of repos. Observe that the repos list afterwards is correct.

### Is there a relevant Issue open for this?
resolves #13 

### People to notify
cc: @day4skiing 
