### PR TITLE
Updating dns-server to run as 'master' by default

### DIFF
--- a/roles/dns-server/defaults/main.yml
+++ b/roles/dns-server/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+default_dns_server_type: 'master'
+
 default_dnssec_keygen_size: 256
 default_dnssec_keygen_algorithm: HMAC-SHA256
 

--- a/roles/dns-server/templates/named.conf.options.j2
+++ b/roles/dns-server/templates/named.conf.options.j2
@@ -17,10 +17,10 @@ options {
 	allow-query { any; };              // This is the default
 {% endif %}
 
-{% if dns_server_type == "master" %}
+{% if dns_server_type|default(default_dns_server_type) == "master" %}
 	also-notify     {
 	{% for server in ansible_play_batch %}
-	{% if hostvars[server].dns_server_type == "slave" %}
+	{% if hostvars[server].dns_server_type|default(default_dns_server_type) == "slave" %}
 		{{ hostvars[server].ansible_default_ipv4.address }};
 	{% endif %}
 	{% endfor %}

--- a/roles/dns-server/templates/named.conf.view.j2
+++ b/roles/dns-server/templates/named.conf.view.j2
@@ -5,13 +5,13 @@ view "{{ view.name }}" {
 
 {% for zone in view.zone %}
 	zone "{{ zone.dns_domain }}" IN {
-		type {{ dns_server_type }};
+		type {{ dns_server_type|default(default_dns_server_type) }};
 		file "static/{{ view.name }}-{{ zone.dns_domain }}.db";
 		allow-update { key {{ view.name }}-{{ zone.dns_domain }}; };
-{% if dns_server_type == "slave" %}
+{% if dns_server_type|default(default_dns_server_type) == "slave" %}
 		masters {
 	{% for server in ansible_play_batch %}
-	{% if hostvars[server].dns_server_type == "master" %}
+	{% if hostvars[server].dns_server_type|default(default_dns_server_type) == "master" %}
 			{{ hostvars[server].ansible_default_ipv4.address }};
 	{% endif %}
 	{% endfor %}


### PR DESCRIPTION
### What does this PR do?
Ensure the DNS server is running as 'master' if the config parameter (master v.s. slave) isn't provided by the caller.

### How should this be tested?
Run the test in the role and ensure the server is running as a "master" type.

### Is there a relevant Issue open for this?
N/A

### People to notify
cc: @day4skiing 
