### PR TITLE
Added dependencies section to metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,1 +1,2 @@
 ---
+dependencies:


### PR DESCRIPTION
### What does this PR do?
Added dependencies section to Ansible Galaxy Metadata file

### How should this be tested?
Corrects issue when this repository is imported as part of an Ansible Galaxy requirements file.

Create a new requirements file called `requirements.yml` with the following content

```
# From 'infra-ansible'
- src: https://github.com/sabre1041/infra-ansible
  version: galaxy-metadata
```

Create a new folder for roles 

```
mkdir roles
```

Import roles

```
ansible-galaxy install -r requirements.yml -p roles
````

### Is there a relevant Issue open for this?
No

### People to notify
cc: @oybed 
