### PR TITLE
Enhancement for F26 to better check for already enabled SSSd/IPA/IdM integration

### DIFF
--- a/roles/config-ipa-client/tasks/ipa-install.yml
+++ b/roles/config-ipa-client/tasks/ipa-install.yml
@@ -140,6 +140,26 @@
     create: yes
 
 - name: "Set up the IPA/IdM client integration"
-  command: ipa-client-install -U --automount-location={{ ipa_automount_location }} -p "{{ ipa_username }}" -w "{{ ipa_password }}" --domain="{{ ipa_domain }}" --force-join
+  command: 'ipa-client-install -U --automount-location={{ ipa_automount_location }} -p "{{ ipa_username }}" -w "{{ ipa_password }}" --domain="{{ ipa_domain }}" --force-join'
 
+- name: "Workaround for missing sss in nsswitch.conf"
+  lineinfile:
+    path: /etc/nsswitch.conf
+    regexp: '^automount:.*files'
+    line: 'automount: files sss'
+    state: present
+  register: automount_line
+
+- name: "Restart sssd if nsswitch.conf was updated"
+  service:
+    name: sssd
+    state: restarted
+  when:
+  - automount_line.changed
  
+- name: "Restart autofs if nsswitch.conf was updated"
+  service:
+    name: autofs
+    state: restarted
+  when:
+  - automount_line.changed

--- a/roles/config-ipa-client/tasks/ipa-install.yml
+++ b/roles/config-ipa-client/tasks/ipa-install.yml
@@ -78,6 +78,8 @@
     state: latest
   with_items:
   - ipa-client
+  - libsss_sudo
+  - sssd-nfs-idmap
 
 - name: "Wait for the previous user to finish up"
   shell: "ps -ef | cut -d' ' -f1 | grep '{{ old_ansible_user }}'"

--- a/roles/config-ipa-client/tasks/ipa.yml
+++ b/roles/config-ipa-client/tasks/ipa.yml
@@ -6,7 +6,20 @@
   failed_when: False
   changed_when: False
 
+- name: "Check if sssd.conf has already been configured - if so skip"
+  stat:
+    path: /etc/sssd/sssd.conf
+  register: stat_result
+  failed_when: False
+  changed_when: False
 
-- name: "Configure IPA/IdM Integration if not already enabled"
+- name: "Check if sssd has already been correctly configured - if so skip"
+  shell: "awk /^.domain.{{ ipa_domain }}.$/ /etc/sssd/sssd.conf"
+  register: check_conf
+  failed_when: False
+  changed_when: False
+
+- name: "Configure IPA/IdM Integration if not already enabled and correctly configured"
   include: ipa-install.yml
-  when: sssd_status.rc != 0
+  when: 
+  - (sssd_status.rc != 0 or stat_result.stat.exists == false or check_conf.stdout == "")


### PR DESCRIPTION
### What does this PR do?
Enhances the SSH / IPA/IdM client integration as F26 already has `sssd` enabled/running by default

### How should this be tested?
Perform a bastion installation with the `ipa_client_install` set to `yes` - verify that the host gets successfully integrated with the IPA/IdM server. 
Perform a second run and validate that the integration isn't failing nor is it tweaked and just kept as-is. 

### Is there a relevant Issue open for this?
resolves #43 

### People to notify
cc: @day4skiing 
