### PR TITLE
Retry DNS role task: Add DNS A Records to avoid timeouts

### DIFF
--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -28,6 +28,6 @@
   - "{{ dns_records_add | default({}) }}"
   - entries
   register: nsupdate_result
-  until: nsupdate_result.dns_rc == 0
+  until: nsupdate_result|succeeded
   retries: 10
   delay: 1

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -27,3 +27,7 @@
   with_subelements:
   - "{{ dns_records_add | default({}) }}"
   - entries
+  register: nsupdate_result
+  until: nsupdate_result.rc == 0
+  retries: 10
+  delay: 1

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -28,6 +28,6 @@
   - "{{ dns_records_add | default({}) }}"
   - entries
   register: nsupdate_result
-  until: nsupdate_result.rc == 0
+  until: nsupdate_result.dns_rc == 0
   retries: 10
   delay: 1

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -12,6 +12,10 @@
   with_subelements:
   - "{{ dns_records_rm | default({}) }}"
   - entries
+  register: nsupdate_remove_result
+  until: nsupdate_remove_result|succeeded
+  retries: 10
+  delay: 1
 
 - name: "Add DNS A records"
   nsupdate:
@@ -27,7 +31,7 @@
   with_subelements:
   - "{{ dns_records_add | default({}) }}"
   - entries
-  register: nsupdate_result
-  until: nsupdate_result|succeeded
+  register: nsupdate_add_result
+  until: nsupdate_add_result|succeeded
   retries: 10
   delay: 1


### PR DESCRIPTION
### What does this PR do?
To avoid transient timeouts when updating the DNS records, retries are added.

### How should this be tested?
1) To check that the task is attempted multiple times, change the expected value in `main.yaml` in `dns/tasks` directory:
- `until: nsupdate_result.dns_rc == 0` to `until: nsupdate_result.dns_rc == 1`
2) Run provisioning with `-vvv`. Task `Add DNS A Records` should be attempted 10 times for each entity and subsequently fail and attempts should be shown in the output.

### Is there a relevant Issue open for this?
--

### People to notify
cc: @tomassedovic 
