### PR TITLE
disable dhcpd when dhcp_service_enabled=false

### DIFF
--- a/roles/dhcp/tasks/dhcp.yml
+++ b/roles/dhcp/tasks/dhcp.yml
@@ -14,3 +14,23 @@
     src: '{{ dhcp_config_temp_loc }}'
     dest: '{{ dhcp_config_dest_file }}'
   notify: 'reload dhcp'
+
+- name: 'Disable dhcp services'
+  service:
+    name: '{{ item }}'
+    enabled: no
+    state: stopped
+  with_items:
+  - dhcpd
+  when: 
+  - dhcp_service_enabled == False
+
+- name: 'Enable dhcp services'
+  service:
+    name: '{{ item }}'
+    enabled: yes
+    state: started
+  with_items:
+  - dhcpd
+  when: 
+  - dhcp_service_enabled|default(True) 


### PR DESCRIPTION
### What does this PR do?
Configures dhcpd server service based on dhcp_service_enabled flag

### How should this be tested?
toggle dhcp_service_enabled flag in inventory run play  and verify dhcp service is in proper state after run.

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #17 

### People to notify
cc: @oybed 
