### PR TITLE
Updating DHCP and PXE to support booting from secondary subnet

### DIFF
--- a/roles/config-pxe/tasks/pxe-target.yml
+++ b/roles/config-pxe/tasks/pxe-target.yml
@@ -1,0 +1,18 @@
+---
+
+- name: "Generate the ip line - if applicable"
+  set_fact:
+    ip_config: "{{ target_entry.ip }}::{{ target_entry.gateway }}:{{ target_entry.netmask }}::{{ target_entry.interface }}:none"
+  when: 
+  - target_entry.ip is defined
+  - target_entry.ip|trim != ''
+
+- name: "(re)set the pxe_entries"
+  set_fact:
+    pxe_entries: "{{ target_entry.pxe_entries }}"
+
+- name: "Populate the host specific grub.cfg (UEFI) file"
+  template:
+    src: pxelinux_uefi.j2
+    dest: "{{ tftpserver_root_dir }}/pxelinux/grub.cfg-01-{{ target_entry.mac|regex_replace(':', '-')|lower }}"
+

--- a/roles/config-pxe/tasks/pxe.yml
+++ b/roles/config-pxe/tasks/pxe.yml
@@ -52,3 +52,9 @@
     src: pxelinux_uefi.j2
     dest: "{{ tftpserver_root_dir }}/pxelinux/grub.cfg"
 
+- name: "Generate target specific UEFI grub.cfg file"
+  include: pxe-target.yml
+  loop_control:
+    loop_var: target_entry
+  with_items:
+  - "{{ pxe_targets }}"

--- a/roles/config-pxe/templates/pxelinux_uefi.j2
+++ b/roles/config-pxe/templates/pxelinux_uefi.j2
@@ -24,7 +24,7 @@ set timeout=60
 ### BEGIN /etc/grub.d/10_linux ###
 {% for entry in pxe_entries %}
 menuentry '{{ entry.name }}' --class fedora --class gnu-linux --class gnu --class os {
-        linuxefi {{ entry.kernel }} inst.gpt ksdevice=bootif inst.sshd inst.text ip=dhcp {{ entry.ks | default('') }} {{ entry.repo | default('') }}
+        linuxefi {{ entry.kernel }} inst.gpt ksdevice=bootif inst.sshd inst.text ip={{ ip_config | default('dhcp') }} {{ entry.ks | default('') }} {{ entry.repo | default('') }}
         initrdefi {{ entry.initrdefi }} 
 }
 {% endfor %}

--- a/roles/dhcp/templates/dhcp_conf.j2
+++ b/roles/dhcp/templates/dhcp_conf.j2
@@ -24,6 +24,21 @@ host {{ entry.host }}  {
 
 {% endfor %}
 
+
+# Define the PXE clients filenames to use for PXE booting
+class "pxeclients" {
+     match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+     if option pxe-system-type = 00:02 {
+             filename "ia64/elilo.efi";
+     } else if option pxe-system-type = 00:06 {
+             filename "pxelinux/bootia32.efi";
+     } else if option pxe-system-type = 00:07 {
+             filename "pxelinux/bootx64.efi";
+     } else {
+             filename "pxelinux.0";
+     }
+}
+
 # Define the Subnets section of the page
 #
 
@@ -38,19 +53,6 @@ subnet {{ entry.subnet }} netmask {{ entry.subnet_mask }} {
      option domain-name         "{{ entry.domain_name }}";
 
      next-server                {{ entry.next_server }};
-
-     class "pxeclients" {
-          match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
-          if option pxe-system-type = 00:02 {
-                  filename "ia64/elilo.efi";
-          } else if option pxe-system-type = 00:06 {
-                  filename "pxelinux/bootia32.efi";
-          } else if option pxe-system-type = 00:07 {
-                  filename "pxelinux/bootx64.efi";
-          } else {
-                  filename "pxelinux.0";
-          }
-     }
 }
 
 {% endfor %}


### PR DESCRIPTION
### What does this PR do?
Fixing PXE booting from a secondary subnet (i.e.: not directly connected with the subnet where the TFTP server sits)

### How should this be tested?
This testing requires quite a bit more of a setup, i.e.:
- A network with  multiple subnets
- A switch/router that can serve as an "IP Helper"
- A DHCP and TFTP server (configured for PXE booting) running on subnet 1
- A target server on subnet 2 (which will PXE boot from subnet 1)

Validate that the PXE booting on subnet 2 works successfully

### Is there a relevant Issue open for this?
N/A

### People to notify
cc: @day4skiing 
