### PR TITLE
Adding a workaround for a uEFI bug with RHEL 7.4

### DIFF
--- a/roles/config-pxe/tasks/pxe-target.yml
+++ b/roles/config-pxe/tasks/pxe-target.yml
@@ -11,8 +11,17 @@
   set_fact:
     pxe_entries: "{{ target_entry.pxe_entries }}"
 
+- name: "Generate the mac-address specific grub.cfg"
+  set_fact:
+    target_file: "{{ tftpserver_root_dir }}/pxelinux/grub.cfg-01-{{ target_entry.mac|regex_replace(':', '-')|lower }}"
+
 - name: "Populate the host specific grub.cfg (UEFI) file"
   template:
     src: pxelinux_uefi.j2
-    dest: "{{ tftpserver_root_dir }}/pxelinux/grub.cfg-01-{{ target_entry.mac|regex_replace(':', '-')|lower }}"
+    dest: "{{ target_file }}"
 
+- name: "Workaround for a RHEL 7.4 uEFI bug where it expects a '-' at the end of the filename"
+  file:
+    src: "{{ target_file }}"
+    dest: "{{ target_file }}-"
+    state: link 


### PR DESCRIPTION
### What does this PR do?
The RHEL 7.4 uEFI PXE implementation incorrectly looks for a file named with a `-` at the end of it - i.e.:
instead of
```
grub.cfg-01-00-1a-e7-47-c1-f1
```
it is looking for:
```
grub.cfg-01-00-1a-e7-47-c1-f1-
```
The workaround is to add symlinks with the added `-` at the end.

### How should this be tested?
PXE boot a uEFI host with a mac address specific grub.cfg file.

### Is there a relevant Issue open for this?
N/A

### People to notify
cc: @day4skiing 
