### PR TITLE
dns-server role to reload at minor changes + keys across multiple master/slaves fix

### DIFF
--- a/roles/dns-server/tasks/generate_keys.yml
+++ b/roles/dns-server/tasks/generate_keys.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Get existing key files
+  shell: 'ls -1 K{{ item }}*.key | sed -ne "s/K\({{ item }}\).*.key/\1/p"'
+  args: 
+    chdir: /var/named/
+  register: key_files
+  ignore_errors: yes
+  with_items:
+  - "{{ dns_views }}"
+
+- name: Build list of existing key files
+  set_fact: 
+    existing_key_files: "{{ existing_key_files | default([]) + [ item.stdout ] }}"
+  with_items:
+  - "{{ key_files.results }}"
+
+- name: Generate keys for nsupdate
+  command: >
+    /sbin/dnssec-keygen
+      -a {{ dnssec_keygen_algorithm | default(default_dnssec_keygen_algorithm) }} 
+      -b {{ dnssec_keygen_size | default(default_dnssec_keygen_size) }}
+      -n USER
+      -r /dev/urandom 
+      -K /var/named {{ item }}
+  with_items:
+  - "{{ dns_views }}"
+  when:
+  - item not in existing_key_files 
+
+- name: Gather keys for nsupdate
+  shell: "grep Key: /var/named/K{{ item }}*.private | cut -d ' ' -f 2"
+  register: nsupdate_keys_captured
+  with_items:
+  - "{{ dns_views }}"
+
+# Build the dict with the proper keys, i.e.:
+#    private-view.example.com:
+#      algorithm: HMAC-MD5 
+#      secret: SKqKNdpfk7llKxZ57bbxUnUDobaaJp9t8CjXLJPl+fRI5mPcSBuxTAyvJPa6Y9R7vUg9DwCy/6WTpgLNqnV4Hg==
+#    public-view.example.com:
+#      algorithm: HMAC-MD5 
+#      secret: kVE2bVTgZjrdJipxPhID8BEZmbHD8cExlVPR+zbFpW6la8kL5wpXiwOh8q5AAosXQI5t95UXwq3Inx8QT58duw==
+- name: Set nsupdate_keys fact
+  set_fact:
+    nsupdate_keys: "{{ nsupdate_keys | default({}) | combine({ item.item : { 'key_algorithm': ( dnssec_keygen_algorithm | default(default_dnssec_keygen_algorithm) ), 'key_secret': item.stdout } }) }}"
+  with_items: "{{ nsupdate_keys_captured.results }}"

--- a/roles/dns-server/tasks/main.yml
+++ b/roles/dns-server/tasks/main.yml
@@ -4,3 +4,4 @@
 - include: named.yml
 - include: named_keys.yml
 - include: named_zones.yml
+- include: print_keys.yml

--- a/roles/dns-server/tasks/named.yml
+++ b/roles/dns-server/tasks/named.yml
@@ -7,6 +7,7 @@
     owner: named 
     group: named
     mode: 0660
+  notify: restart named
 
 - name: Setup DNS Logging configuration
   template: 
@@ -15,6 +16,7 @@
     owner: named
     group: named
     mode: 0660
+  notify: restart named
 
 - name: Setup Controls configuration
   template:
@@ -23,6 +25,7 @@
     owner: named
     group: named
     mode: 0660
+  notify: restart named
 
 - name: Configure named options
   template:
@@ -30,6 +33,7 @@
     dest: /etc/named/named.conf.options
     owner: named
     group: named 
+  notify: restart named
 
 - name: Setup Domain Keys configuration
   template:
@@ -38,4 +42,5 @@
     owner: named
     group: named
     mode: 0660
+  notify: restart named
 

--- a/roles/dns-server/tasks/named_keys.yml
+++ b/roles/dns-server/tasks/named_keys.yml
@@ -9,51 +9,9 @@
     mode: 0660
   notify: restart named
 
-- name: Get existing key files
-  shell: 'ls -1 K{{ item }}*.key | sed -ne "s/K\({{ item }}\).*.key/\1/p"'
-  args: 
-    chdir: /var/named/
-  register: key_files
-  ignore_errors: yes
-  with_items:
-  - "{{ dns_views }}"
-
-- name: Build list of existing key files
-  set_fact: 
-    existing_key_files: "{{ existing_key_files | default([]) + [ item.stdout ] }}"
-  with_items:
-  - "{{ key_files.results }}"
-
-- name: Generate keys for nsupdate
-  command: >
-    /sbin/dnssec-keygen
-      -a {{ dnssec_keygen_algorithm | default(default_dnssec_keygen_algorithm) }} 
-      -b {{ dnssec_keygen_size | default(default_dnssec_keygen_size) }}
-      -n USER
-      -r /dev/urandom 
-      -K /var/named {{ item }}
-  with_items:
-  - "{{ dns_views }}"
-  when:
-  - item not in existing_key_files 
-
-- name: Gather keys for nsupdate
-  shell: "grep Key: /var/named/K{{ item }}*.private | cut -d ' ' -f 2"
-  register: nsupdate_keys_captured
-  with_items:
-  - "{{ dns_views }}"
-
-# Build the dict with the proper keys, i.e.:
-#    private-view.example.com:
-#      algorithm: HMAC-MD5 
-#      secret: SKqKNdpfk7llKxZ57bbxUnUDobaaJp9t8CjXLJPl+fRI5mPcSBuxTAyvJPa6Y9R7vUg9DwCy/6WTpgLNqnV4Hg==
-#    public-view.example.com:
-#      algorithm: HMAC-MD5 
-#      secret: kVE2bVTgZjrdJipxPhID8BEZmbHD8cExlVPR+zbFpW6la8kL5wpXiwOh8q5AAosXQI5t95UXwq3Inx8QT58duw==
-- name: Set nsupdate_keys fact
-  set_fact:
-    nsupdate_keys: "{{ nsupdate_keys | default({}) | combine({ item.item : { 'key_algorithm': ( dnssec_keygen_algorithm | default(default_dnssec_keygen_algorithm) ), 'key_secret': item.stdout } }) }}"
-  with_items: "{{ nsupdate_keys_captured.results }}"
+- include: generate_keys.yml
+  run_once: true
+  delegate_to: "{{ ansible_play_hosts | first }}"
 
 - name: Setup key files for nsupdate
   template:
@@ -63,6 +21,6 @@
     group: named
     mode: 0660
   with_items:
-  - "{{ nsupdate_keys_captured.results }}"
+  - "{{ hostvars[ansible_play_hosts | first].nsupdate_keys_captured.results }}"
   notify: restart named
 

--- a/roles/dns-server/tasks/named_keys.yml
+++ b/roles/dns-server/tasks/named_keys.yml
@@ -7,6 +7,7 @@
     owner: named
     group: named
     mode: 0660
+  notify: restart named
 
 - name: Get existing key files
   shell: 'ls -1 K{{ item }}*.key | sed -ne "s/K\({{ item }}\).*.key/\1/p"'
@@ -63,4 +64,5 @@
     mode: 0660
   with_items:
   - "{{ nsupdate_keys_captured.results }}"
+  notify: restart named
 

--- a/roles/dns-server/tasks/print_keys.yml
+++ b/roles/dns-server/tasks/print_keys.yml
@@ -1,0 +1,7 @@
+---
+
+- name: "Print configured keys - if requested"
+  debug:
+    var: nsupdate_keys
+  when:
+  - print_dns_keys|default(False)

--- a/roles/dns-server/tasks/print_keys.yml
+++ b/roles/dns-server/tasks/print_keys.yml
@@ -3,5 +3,7 @@
 - name: "Print configured keys - if requested"
   debug:
     var: nsupdate_keys
+  run_once: true
   when:
   - print_dns_keys|default(False)
+  delegate_to: "{{ ansible_play_hosts | first }}"

--- a/roles/dns-server/templates/named.conf.view.j2
+++ b/roles/dns-server/templates/named.conf.view.j2
@@ -12,7 +12,7 @@ view "{{ view.name }}" {
 		masters {
 	{% for server in ansible_play_batch %}
 	{% if hostvars[server].dns_server_type|default(default_dns_server_type) == "master" %}
-			{{ hostvars[server].ansible_default_ipv4.address }};
+			{{ hostvars[server].ansible_default_ipv4.address }} key {{ view.name }}-{{ zone.dns_domain }};
 	{% endif %}
 	{% endfor %}
 		};

--- a/roles/dns-server/test/test.yml
+++ b/roles/dns-server/test/test.yml
@@ -12,7 +12,7 @@
       - dns_domain: first.example.com
       - dns_domain: second.example.com
       - dns_domain: third.example.com
-      - dns_domain: forth.example.com
+      - dns_domain: fifth.example.com
     - name: public
       zone:
       - dns_domain: first.example.com

--- a/roles/dns-server/test/test.yml
+++ b/roles/dns-server/test/test.yml
@@ -12,7 +12,7 @@
       - dns_domain: first.example.com
       - dns_domain: second.example.com
       - dns_domain: third.example.com
-      - dns_domain: fifth.example.com
+      - dns_domain: forth.example.com
     - name: public
       zone:
       - dns_domain: first.example.com


### PR DESCRIPTION
### What does this PR do?
Updated `dns-server` role with 2 changes:
 - added a restart to any task that may change configuration
 - added an option ( `print_dns_keys` ) to allow for the caller to dump the DNS keys configured

### How should this be tested?
1. Provision a DNS server using the test in the `tests` directory
1a. Check that the DNS server is working
2. Re-run and observe that no changes are made and the bind server is NOT restarted
3. Add a small change to the test - i.e.: an additional ACL entry
3a. re-run and observe that the bind server was restarted
4. re-run with `print_dns_keys` set to `True` and observe that the DNS keys are printed

### Is there a relevant Issue open for this?
resolves #67

### People to notify
cc: @bogdando
