### PR TITLE
Updated dns-server role to allow for more global config options

### DIFF
--- a/roles/dns-server/README.md
+++ b/roles/dns-server/README.md
@@ -11,6 +11,10 @@ This role installs and configures bind/named for use with multiple views and zon
   - hosts: dns-servers
     roles:
     - role: dns-server
+      named_config_recursion: 'no'
+      named_config_dnssec_enable: 'no'
+      named_config_dnssec_validation: 'no'
+      named_config_dnssec_lookaside: 'auto'
       named_config_allow_transfer:
       - "192.168.10.11"
       - "192.168.10.12"

--- a/roles/dns-server/templates/named.conf.options.j2
+++ b/roles/dns-server/templates/named.conf.options.j2
@@ -48,11 +48,11 @@ options {
 	   attacks. Implementing BCP38 within your network would greatly
 	   reduce such attack surface
 	*/
-	recursion yes;
+	recursion {{ named_config_recursion | default('yes') }};
 
-	dnssec-enable no;
-	dnssec-validation no;
-	dnssec-lookaside auto;
+	dnssec-enable {{ named_config_dnssec_enable | default('no') }};
+	dnssec-validation {{ named_config_dnssec_validation | default('no') }};
+	dnssec-lookaside {{ named_config_dnssec_lookaside | default('auto') }};
 
 	/* Path to ISC DLV key */
 	bindkeys-file "/etc/named.iscdlv.key";

--- a/roles/dns-server/test/test.yml
+++ b/roles/dns-server/test/test.yml
@@ -3,6 +3,10 @@
 - hosts: dns-server
   roles:
   - role: dns-server
+    named_config_recursion: 'no'
+    named_config_dnssec_enable: 'yes'
+    named_config_dnssec_validation: 'yes'
+    named_config_dnssec_lookaside: 'no'
     named_config_views:
     - name: private
       acl_entry: 


### PR DESCRIPTION
### What does this PR do?
Added in additional global options for dns-server (bind/named) to allow for things like setting `recursion` to no, etc. 

### How should this be tested?
Run the test in the `tests` directory, pointing to an operational CentOS or RHEL instance (RHEL needs to be correctly subscribed). Validate the content of the `/etc/named/named.conf.options` file.

### Is there a relevant Issue open for this?
resolves #65

### People to notify
cc: @day4skiing @tomassedovic @bogdando
