### PR TITLE
Apply global recursion option to views if not locally specified

### DIFF
--- a/roles/dns-server/defaults/main.yml
+++ b/roles/dns-server/defaults/main.yml
@@ -5,6 +5,8 @@ default_dns_server_type: 'master'
 default_dnssec_keygen_size: 256
 default_dnssec_keygen_algorithm: HMAC-SHA256
 
+named_config_recursion: yes
+
 named_config_views: []
 named_config_allow_query: []
 named_config_allow_transfer: []

--- a/roles/dns-server/templates/named.conf.view.j2
+++ b/roles/dns-server/templates/named.conf.view.j2
@@ -1,7 +1,8 @@
 {% for view in named_config_views %}
 view "{{ view.name }}" {
 	match-clients { "{{ view.name }}"; };
-	recursion {{ view.recursion | default('yes') }};
+
+	recursion {{ view.recursion | default(named_config_recursion) }};
 
 {% for zone in view.zone %}
 	zone "{{ zone.dns_domain }}" IN {

--- a/roles/dns-server/test/test.yml
+++ b/roles/dns-server/test/test.yml
@@ -9,6 +9,7 @@
     named_config_dnssec_lookaside: 'no'
     named_config_views:
     - name: private
+      recursion: 'yes'
       acl_entry: 
       - 172.16.0.0/16
       - 172.17.0.0/16


### PR DESCRIPTION
### What does this PR do?
Enhancing the view level recursion to default to global value if not set locally within the view. 

### How should this be tested?
Run the tests in the `test` directory and observe that global and public views are set to `no`, while the private view is set to `yes`.

### Is there a relevant Issue open for this?
N/A

### People to notify
cc: @day4skiing @bogdando
