### PR TITLE
Fix yes/no conditionals to use True/False instead

### DIFF
--- a/playbooks/bastion/README.md
+++ b/playbooks/bastion/README.md
@@ -13,7 +13,7 @@ If the IdM / IPA integration is to be used, it is a prerequisites that the envir
 2. When enabling VNC, and you already have a shared home directory, make sure the proper changes are made to the VNC configuration (typically in `~/.vnc` ) to allow for the service to run correctly.
 
 ## Example run
-How to run the playbook may depend on the options selected. However, below is an example execution whereas the password for IPA/IdM integration (with `ipa_client_install` set to "yes" in the inventory) is passed in rather than statically set in the inventory. Modify the inventory to your liking in `playbooks/bastion/inventory`, then at the top level of the repository, execute the following command:
+How to run the playbook may depend on the options selected. However, below is an example execution whereas the password for IPA/IdM integration (with `ipa_client_install` set to `True` in the inventory) is passed in rather than statically set in the inventory. Modify the inventory to your liking in `playbooks/bastion/inventory`, then at the top level of the repository, execute the following command:
 
 ```
 > ansible-playbook -i playbooks/bastion/inventory playbooks/bastion/install.yml -e 'ipa_password=<ipa/IdM password>'
@@ -30,16 +30,16 @@ How to run the playbook may depend on the options selected. However, below is an
 | variable | info |
 |:--------:|:----:|
 |main_user|The username this bastion is primerly being enabled for|
-|ipa_client_install|Set to "yes" if you'd like to integrate with a backend IPA/IdM service|
-|ipa_domain|If `ipa_client_install` is set to "yes", set this to the existing IdM / IPA domain your environment uses (obtain from sys admin if not known)|
-|ipa_automount_location|If `ipa_client_install` is set to "yes", set the required automount location for home directories (obtain from sys admin if not known)|
-|ipa_username|If `ipa_client_install` is set to "yes", this is the username of an account that has the permission to join this host to the above IPA/IdM domain (obtain from sys admin if not known)|
-|ipa_password|If `ipa_client_install` is set to "yes", this is the password of an account that has the permission to join this host to the above IPA/IdM domain (obtain from sys admin if not known)
-|docker_install|Set to "yes" if you'd like to enable docker on this host|
+|ipa_client_install|Set to `True` if you'd like to integrate with a backend IPA/IdM service|
+|ipa_domain|If `ipa_client_install` is set to `True`, set this to the existing IdM / IPA domain your environment uses (obtain from sys admin if not known)|
+|ipa_automount_location|If `ipa_client_install` is set to `True`, set the required automount location for home directories (obtain from sys admin if not known)|
+|ipa_username|If `ipa_client_install` is set to `True`, this is the username of an account that has the permission to join this host to the above IPA/IdM domain (obtain from sys admin if not known)|
+|ipa_password|If `ipa_client_install` is set to `True`, this is the password of an account that has the permission to join this host to the above IPA/IdM domain (obtain from sys admin if not known)
+|docker_install|Set to `True` if you'd like to enable docker on this host|
 |docker_username|Set to the desirable user (your username) to be added to the docker group (to allow for docker admin)|
-|docker_compose_install|Set to "yes" if you'd like to have docker-compose installed on this host. NOTE: This will auto set docker_install=yes (not supported on CentOS)|
-|xfce_install|Set to "yes" if you'd like XFCE enabled on this host for a graphical UI (note XFCE or LXDE often works better than gnome for VNC)|
-|lxde_install|Set to "yes" if you'd like LXDE enabled on this host for a graphical UI (note XFCE or LXDE often works better than gnome for VNC)|
-|gnome_install|Set to "yes" if you'd like gnome enabled on this host for a graphical UI|
-|vnc_server_install|Set to "yes" if you'd like to enable a VNC server on this host for graphical access to the host|
+|docker_compose_install|Set to `True` if you'd like to have docker-compose installed on this host. NOTE: This will auto set docker_install=yes (not supported on CentOS)|
+|xfce_install|Set to `True` if you'd like XFCE enabled on this host for a graphical UI (note XFCE or LXDE often works better than gnome for VNC)|
+|lxde_install|Set to `True` if you'd like LXDE enabled on this host for a graphical UI (note XFCE or LXDE often works better than gnome for VNC)|
+|gnome_install|Set to `True` if you'd like gnome enabled on this host for a graphical UI|
+|vnc_server_install|Set to `True` if you'd like to enable a VNC server on this host for graphical access to the host|
 |additional_tools_packages|List of additional packages (RPMs) to be installed at the end of the bastion host preparation, e.g.: `['git', 'vim']`|

--- a/playbooks/bastion/inventory-centos
+++ b/playbooks/bastion/inventory-centos
@@ -1,12 +1,12 @@
 [all:vars]
 main_user=testuser
 
-ipa_client_install=yes
+ipa_client_install=True
 ipa_domain=example.com
 ipa_automount_location=userhome
 ipa_username=testuser
 
-docker_install=yes
+docker_install=True
 docker_username=testuser
 
 [bastion]

--- a/playbooks/bastion/inventory-fedora
+++ b/playbooks/bastion/inventory-fedora
@@ -1,18 +1,18 @@
 [all:vars]
 main_user=fedora
 
-ipa_client_install=yes
+ipa_client_install=True
 ipa_domain=example.com
 ipa_automount_location=userhome
 ipa_username=testuser
 ipa_password=my-super-secret-password
 
-docker_install=yes
+docker_install=True
 docker_username=testuser
-docker_compose_install=yes
+docker_compose_install=True
 
-xfce_install=yes
-vnc_server_install=yes
+xfce_install=True
+vnc_server_install=True
 
 additional_tools_packages=['git']
 

--- a/roles/config-docker/tasks/main.yml
+++ b/roles/config-docker/tasks/main.yml
@@ -3,5 +3,5 @@
 - name: "Install, configure and enable Docker"
   include: docker.yml
   when: 
-  - docker_install|default('no') == "yes"
+  - docker_install|default(False)
 

--- a/roles/config-gnome/tasks/main.yml
+++ b/roles/config-gnome/tasks/main.yml
@@ -9,5 +9,5 @@
   loop_control:
     loop_var: distro_file
   when:
-  - gnome_install|default('no') == "yes"
+  - gnome_install|default(False)
 

--- a/roles/config-ipa-client/tasks/main.yml
+++ b/roles/config-ipa-client/tasks/main.yml
@@ -3,4 +3,4 @@
 - name: "Install, configure and enable IPA/IdM integration"
   include: ipa.yml
   when: 
-  - ipa_client_install|default('no') == "yes"
+  - ipa_client_install|default(False)

--- a/roles/config-lxde/tasks/main.yml
+++ b/roles/config-lxde/tasks/main.yml
@@ -9,5 +9,5 @@
   loop_control:
     loop_var: distro_file
   when:
-  - lxde_install|default('no') == "yes"
+  - lxde_install|default(False)
 

--- a/roles/config-vnc-server/tasks/main.yml
+++ b/roles/config-vnc-server/tasks/main.yml
@@ -3,10 +3,10 @@
 - name: "Prep for VNC server install"
   include: prereq.yml
   when: 
-  - vnc_server_install == "yes"
+  - vnc_server_install|default(False)
 
 - name: "Install, configure and enable VNC server"
   include: vnc-server.yml
   when: 
-  - vnc_server_install|default('no') == "yes"
+  - vnc_server_install|default(False)
 

--- a/roles/config-vnc-server/tasks/vnc-server.yml
+++ b/roles/config-vnc-server/tasks/vnc-server.yml
@@ -38,7 +38,7 @@
     owner: "{{ main_user }}"
     mode: 0755
   when:
-  - gnome_install|default('no') == "yes"
+  - gnome_install|default(False)
 
 - name: "Add the xstartup (XFCE) configuration to the main user"
   copy :
@@ -48,7 +48,7 @@
     owner: "{{ main_user }}"
     mode: 0755
   when:
-  - xfce_install|default('no') == "yes"
+  - xfce_install|default(False)
 
 - name: "Add the xstartup (LXDE) configuration to the main user"
   copy :
@@ -58,7 +58,7 @@
     owner: "{{ main_user }}"
     mode: 0755
   when:
-  - lxde_install|default('no') == "yes"
+  - lxde_install|default(False)
 
 - name: "Copy VNC service file into place" 
   copy:

--- a/roles/config-xfce/tasks/main.yml
+++ b/roles/config-xfce/tasks/main.yml
@@ -9,5 +9,5 @@
   loop_control:
     loop_var: distro_file
   when:
-  - xfce_install|default('no') == "yes"
+  - xfce_install|default(False)
 


### PR DESCRIPTION
### What does this PR do?
It appears that various versions of Ansible interpret `yes` v.s. `"yes"` differently (newer versions of Ansible is most likely more correct than the older ones). To avoid running into issues; the conditionals are now using True/False instead to eliminate any ambiguity.

### How should this be tested?
Use the `bastion` install playbook with a proper inventory using True/False for conditionals.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
