### PR TITLE
Adding check for user in docker role

### DIFF
--- a/roles/config-docker/tasks/docker.yml
+++ b/roles/config-docker/tasks/docker.yml
@@ -14,6 +14,11 @@
     enabled: yes
     state: started
 
+# This task will error out if the user doesn't exist
+- name: "Check to see if the targeted docker user exists"
+  command: id "{{ docker_username }}"
+  changed_when: false
+
 - name: "Add docker group"
   group:
     name: docker


### PR DESCRIPTION
### What does this PR do?
Adding a check for the requested `docker_username` to ensure it exists before running the docker role since otherwise it be unexpectedly added. 

### How should this be tested?
1) Run the `config-docker` role with a non-existing `docker_username`, the role should error out. 
2) Run the `config-docker` role with an existing `docker_username`, the role should succeed

### Is there a relevant Issue open for this?
resolves #91 

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible 

@etsauer  FYI ...
