### PR TITLE
Adding tower health check

### DIFF
--- a/roles/config-ansibletower/tasks/install.yml
+++ b/roles/config-ansibletower/tasks/install.yml
@@ -29,6 +29,18 @@
   args:
     chdir: "{{ ansible_tower_dir }}"
 
+- name: "Wait for Tower to become available before proceeding (30 sec max)"
+  uri:
+    url: https://localhost/api/v1/config/
+    method: GET
+    user: admin
+    password: "{{ tower_admin_password }}"
+    validate_certs: no
+  register: status_output
+  until: status_output.status == 200
+  retries: 6
+  delay: 5
+
 - name: "Add Tower license"
   uri: 
     url: https://localhost/api/v1/config/


### PR DESCRIPTION
### What does this PR do?
Adding a check to ensure the Tower REST API is available before proceeding.

### How should this be tested?
Run the installation of Tower

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
