### PR TITLE
.novalocal workaround

### DIFF
--- a/playbooks/osp/provision-osp-instance.yml
+++ b/playbooks/osp/provision-osp-instance.yml
@@ -29,13 +29,27 @@
       delay: 10
       timeout: 300
 
-- name: Workaround for .novalocal
+- name: "Workaround for .novalocal"
   hosts: osp_instances
   tasks:
-  - hostname:
+  - name: "Eliminate the .novalocal at the end of the FQDN"
+    hostname:
       name: "{{ ansible_fqdn | regex_replace('(.*).novalocal$', '\\1') }}"
-  - lineinfile:
+  - name: "Ensure the local host can resolve by its own IP"
+    lineinfile:
       path: /etc/hosts
-      regexp: "^{{ ansible_host }}.*"
+      regexp: "^{{ ansible_default_ipv4.address }}.*"
       line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn | regex_replace('(.*).novalocal$', '\\1') }}"
+  - name: "Ensure the changes stick during reboot"
+    stat: path=/etc/cloud/cloud.cfg
+    register: cloud_cfg
+  - lineinfile:
+      dest: /etc/cloud/cloud.cfg
+      state: present
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    with_items:
+    - { regexp: '^ - set_hostname', line: '# - set_hostname' }
+    - { regexp: '^ - update_hostname', line: '# - update_hostname' }
+    when: cloud_cfg.stat.exists == True
 

--- a/playbooks/osp/provision-osp-instance.yml
+++ b/playbooks/osp/provision-osp-instance.yml
@@ -29,3 +29,13 @@
       delay: 10
       timeout: 300
 
+- name: Workaround for .novalocal
+  hosts: osp_instances
+  tasks:
+  - hostname:
+      name: "{{ ansible_fqdn | regex_replace('(.*).novalocal$', '\\1') }}"
+  - lineinfile:
+      path: /etc/hosts
+      regexp: "^{{ ansible_host }}.*"
+      line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn | regex_replace('(.*).novalocal$', '\\1') }}"
+


### PR DESCRIPTION
### What does this PR do?
Due to what appears to be a bug (or mis-configuration - TBD) with OSP 11, we need a workaround to eliminate the `.novalocal` from hostnames. 

### How should this be tested?
Run any provisioning with the `osp` roles/playbooks and see that the hostname (fqdn) does not include `.novalocal` at the end.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
