### PR TITLE
Bastion timezone setting

### DIFF
--- a/playbooks/bastion/README.md
+++ b/playbooks/bastion/README.md
@@ -43,4 +43,4 @@ How to run the playbook may depend on the options selected. However, below is an
 |gnome_install|Set to `True` if you'd like gnome enabled on this host for a graphical UI|
 |vnc_server_install|Set to `True` if you'd like to enable a VNC server on this host for graphical access to the host|
 |additional_tools_packages|List of additional packages (RPMs) to be installed at the end of the bastion host preparation, e.g.: `['git', 'vim']`|
-|timezone| Timezone of the Bastion ie `America/Denver`|
+|timezone| `Optional` Timezone of the Bastion ie `America/Denver`|

--- a/playbooks/bastion/README.md
+++ b/playbooks/bastion/README.md
@@ -43,3 +43,4 @@ How to run the playbook may depend on the options selected. However, below is an
 |gnome_install|Set to `True` if you'd like gnome enabled on this host for a graphical UI|
 |vnc_server_install|Set to `True` if you'd like to enable a VNC server on this host for graphical access to the host|
 |additional_tools_packages|List of additional packages (RPMs) to be installed at the end of the bastion host preparation, e.g.: `['git', 'vim']`|
+|timezone| Timezone of the Bastion ie `America/Denver`|

--- a/playbooks/bastion/install.yml
+++ b/playbooks/bastion/install.yml
@@ -10,6 +10,7 @@
 - name: 'Install and Configure the bastion host'
   hosts: bastion
   roles:
+  - role: config-timezone
   - role: update-host
   - role: config-ipa-client
   - role: config-docker

--- a/playbooks/bastion/inventory/group_vars/all.yml
+++ b/playbooks/bastion/inventory/group_vars/all.yml
@@ -1,0 +1,3 @@
+---
+
+timezone: America/Denver

--- a/playbooks/bastion/inventory/group_vars/all.yml
+++ b/playbooks/bastion/inventory/group_vars/all.yml
@@ -1,3 +1,0 @@
----
-
-timezone: America/Denver

--- a/playbooks/bastion/inventory/group_vars/bastion.yml
+++ b/playbooks/bastion/inventory/group_vars/bastion.yml
@@ -20,3 +20,6 @@ vnc_server_install: False
 additional_tools_packages:
 - git
 
+# 
+# Optional setting
+# timezone: America/Denver


### PR DESCRIPTION
### What does this PR do?
add config-timezone role to bastion install playbook

### How should this be tested?
`ansible-playbook -i playbooks/bastion/inventory playbooks/bastion/install.yml'
#### Note the new `optional` variable in `bastion.yml` :  `timezone`

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
This is dependent on PR #107 being merged

### People to notify
cc: @redhat-cop/infra-ansible
