### PR TITLE
Fixing Ansible 2.4 dep warnings + docker-compose dependency check

### DIFF
--- a/roles/config-docker-compose/meta/main.yml
+++ b/roles/config-docker-compose/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - { role: config-docker, docker_install: 'yes' }

--- a/roles/config-docker-compose/tasks/main.yml
+++ b/roles/config-docker-compose/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 
+- name: "Make sure dependencies are met"
+  vars: 
+    docker_install: True
+  include_role:
+    name: config-docker
+  when:
+  - docker_compose_install|default(False)
+
 - name: "Install, configure and enable Docker-compose"
-  include: docker-compose.yml
+  import_tasks: docker-compose.yml
   when:
   - docker_compose_install|default(False)

--- a/roles/config-docker/tasks/main.yml
+++ b/roles/config-docker/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Install, configure and enable Docker"
-  include: docker.yml
+  import_tasks: docker.yml
   when: 
   - docker_install|default(False)
 

--- a/roles/config-gnome/tasks/main.yml
+++ b/roles/config-gnome/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Install, configure and enable Gnome"
-  include: "{{ distro_file }}"
+  include_tasks: "{{ distro_file }}"
   with_first_found:
   - files:
     - gnome-{{ ansible_distribution }}.yml

--- a/roles/config-ipa-client/tasks/ipa-install.yml
+++ b/roles/config-ipa-client/tasks/ipa-install.yml
@@ -5,7 +5,7 @@
     move_user: False
 
 - name: "Include prereqs per the type of OS"
-  include: "{{ distro_file }}"
+  include_tasks: "{{ distro_file }}"
   with_first_found:
   - files:
     - prereq-{{ ansible_distribution }}.yml

--- a/roles/config-ipa-client/tasks/ipa.yml
+++ b/roles/config-ipa-client/tasks/ipa.yml
@@ -20,6 +20,6 @@
   changed_when: False
 
 - name: "Configure IPA/IdM Integration if not already enabled and correctly configured"
-  include: ipa-install.yml
+  import_tasks: ipa-install.yml
   when: 
   - (sssd_status.rc != 0 or stat_result.stat.exists == false or check_conf.stdout == "")

--- a/roles/config-ipa-client/tasks/main.yml
+++ b/roles/config-ipa-client/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: "Install, configure and enable IPA/IdM integration"
-  include: ipa.yml
+  import_tasks: ipa.yml
   when: 
   - ipa_client_install|default(False)

--- a/roles/config-lxde/tasks/main.yml
+++ b/roles/config-lxde/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Install, configure and enable LXDE"
-  include: "{{ distro_file }}"
+  include_tasks: "{{ distro_file }}"
   with_first_found:
   - files:
     - lxde-{{ ansible_distribution }}.yml

--- a/roles/config-vnc-server/tasks/main.yml
+++ b/roles/config-vnc-server/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: "Prep for VNC server install"
-  include: prereq.yml
+  import_tasks: prereq.yml
   when: 
   - vnc_server_install|default(False)
 
 - name: "Install, configure and enable VNC server"
-  include: vnc-server.yml
+  import_tasks: vnc-server.yml
   when: 
   - vnc_server_install|default(False)
 

--- a/roles/config-xfce/tasks/main.yml
+++ b/roles/config-xfce/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Install, configure and enable XFCE"
-  include: "{{ distro_file }}"
+  include_tasks: "{{ distro_file }}"
   with_first_found:
   - files:
     - xfce-{{ ansible_distribution }}.yml


### PR DESCRIPTION
### What does this PR do?
Fixing Ansible 2.4 deprecated warnings related to the bastion playbook + fixing docker-compose dependency check

### How should this be tested?
Run the bastion playbook

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
