### PR TITLE
Add support for network admin in a specific project

### DIFF
--- a/roles/osp/admin-network/tasks/manage-networks.yml
+++ b/roles/osp/admin-network/tasks/manage-networks.yml
@@ -3,6 +3,7 @@
 - name: "Set up network(s)"
   os_network:
     cloud: "{{ item.cloud | default(osp_default_cloud) | default(omit) }}"
+    project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(osp_resource_state) | default('present') }}"
     name: "{{ item.name }}"
     external: "{{ item.external | default(False) }}"

--- a/roles/osp/admin-network/tasks/manage-routers.yml
+++ b/roles/osp/admin-network/tasks/manage-routers.yml
@@ -3,6 +3,7 @@
 - name: "Set up router(s)"
   os_router:
     cloud: "{{ item.cloud | default(osp_default_cloud) | default(omit) }}"
+    project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(osp_resource_state) | default('present') }}"
     name: "{{ item.name }}"
     network: "{{ item.external_gateway }}"


### PR DESCRIPTION
### What does this PR do?
When running the admin from a "centralized" user (such as admin), it is useful to be able to specify which project to target for setting up the networking. This PR adds the `project` parameter for networks and routers.

### How should this be tested?
With a user with access to more than one project/tenant, use the `tests` directory inventory and add `project` to the `osp_networks`, `osp_subnets` and `osp_routers` and observe that the configuration gets added to the correct project. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
