### PR TITLE
Adding playbook to allow for subscription-management of hosts

### DIFF
--- a/playbooks/subscribe-host.yml
+++ b/playbooks/subscribe-host.yml
@@ -1,0 +1,7 @@
+---
+
+# Example run (localhost needed to source username/password with "prep.yml") 
+# > ansible-playbook -i <inventory> subscribe-host.yml -l "myhosts,localhost" 
+
+- import_playbook: "prep.yml"
+- import_playbook: "rhsm.yml"


### PR DESCRIPTION
### What does this PR do?
Adding playbook to do subscription-management for hosts  - i.e.: 
- call `prep.yml` to prompt for username/password
- call `rhsm.yml` to subscribe

### How should this be tested?
Use the `subscribe-host.yml` playbook to subscribe one or more host(s)

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
