### PR TITLE
Enhancing the rhsm playbook

### DIFF
--- a/playbooks/rhsm.yml
+++ b/playbooks/rhsm.yml
@@ -1,6 +1,8 @@
 ---
 
-# Make sure to run the "prep.yml" playbook before running this playbook
+# If you want to use username/password for subscription, please ensure 
+# to run the "prep.yml" playbook before running this playbook 
+# - alternatively use the "subscribe-host.yml" playbook instead
 
 - hosts: rhsm_hosts
   vars:

--- a/playbooks/rhsm.yml
+++ b/playbooks/rhsm.yml
@@ -2,10 +2,10 @@
 
 # Make sure to run the "prep.yml" playbook before running this playbook
 
-- hosts: infra_vms
+- hosts: rhsm_hosts
   vars:
-    rhsm_username: "{{ hostvars['localhost'].rhsm_username }}"
-    rhsm_password: "{{ hostvars['localhost'].rhsm_password }}"
+    rhsm_username: "{{ hostvars['localhost'].rhsm_username | default(omit) }}"
+    rhsm_password: "{{ hostvars['localhost'].rhsm_password | default(omit) }}"
   roles: 
   - role: rhsm
     no_log: True

--- a/playbooks/subscribe-host.yml
+++ b/playbooks/subscribe-host.yml
@@ -1,0 +1,7 @@
+---
+
+# Example run (localhost needed to source username/password with "prep.yml") 
+# > ansible-playbook -i <inventory> subscribe-host.yml -l "myhosts,localhost" 
+
+- import_playbook: "prep.yml"
+- import_playbook: "rhsm.yml"


### PR DESCRIPTION
### What does this PR do?
Enhancing the `rhsm` playbook to allow for a broader use - including directly with Satellite registrations. 

### How should this be tested?

Add the following to your inventory (or something similar that populates the `rhsm_hosts` group):
```
[rhsm_hosts:children]
cluster_hosts
```
+ the necessary rhsm variables.
... then run the `rhsm.yml` playbook

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
