### PR TITLE
Adding 'ssh' back into the 'ansible_hosts'

### DIFF
--- a/roles/update-host/tasks/main.yml
+++ b/roles/update-host/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: "waiting for server to come back"
   local_action: wait_for
   args:
-    host: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
+    host: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
     port: 22
     delay: 15
     timeout: 300


### PR DESCRIPTION
### What does this PR do?
The Ansible docs state that "ssh" has been removed from these variables, but when using "ansible_host" it just doesn't work, so adding "ssh" back to eliminate "breakage". 

### How should this be tested?
Use the "update-host" role and see that it's successful 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
