### PR TITLE
Updating the 'update-host' role to allow greater flexibility

### DIFF
--- a/roles/update-host/README.md
+++ b/roles/update-host/README.md
@@ -1,50 +1,93 @@
-# update-hosts role
+Role Name
+=========
 
 This role performs updates and reboots a host (and waits for it to come back).
 
-## Role Variables
 
-`pkg_update` variable controls the package updates in the role.
+Requirements
+------------
+
+A Linux distro supporting the `package` module.
+
+Role Variables
+--------------
+
+`pkg_update`: Optional variable controls if packages should be updated or not (useful to avoid surprises when this role is part of a bigger playbook).
+`force_host_reboot`: Optional variable to force a reboot even if no updates were performed.
 
 | Name | What | Default|
 |---|---|---|
 |pkg_update|Boolean|False|
+|force_host_reboot|Boolean|False|
 
 
-#### Inventory example 1:
+Dependencies
+------------
+
+N/A
+
+Example Playbook
+----------------
+
+```
+  - hosts: servers
+    roles:
+      - role: update-host
+```
+
+
+Example Inventory 1
+-------------------
+
 Enable updates on all hosts
 
 ```
-[all:vars]
-pkg_update=True
+  [all:vars]
+  pkg_update=True
 
-[test_hosts]
-host1.test.lab ansible_user=root ansible_host=192.168.1.1
-host2.test.lab ansible_user=root ansible_host=192.168.1.2
+  [test_hosts]
+  host1.test.lab ansible_user=root ansible_host=192.168.1.1
+  host2.test.lab ansible_user=root ansible_host=192.168.1.2
 ```
 
-#### Inventory example 2:
+Example Inventory 2
+-------------------
+
 Enable updates on all hosts except 1
 
 ```
-[all:vars]
-pkg_update=True
+  [all:vars]
+  pkg_update=True
 
-[test_hosts]
-host1.test.lab ansible_user=root ansible_host=192.168.1.1
-host2.test.lab ansible_user=root ansible_host=192.168.1.2 pkg_update=False
+  [test_hosts]
+  host1.test.lab ansible_user=root ansible_host=192.168.1.1
+  host2.test.lab ansible_user=root ansible_host=192.168.1.2 pkg_update=False
 
 ```
 
-#### Inventory example 3:
+Example Inventory 3
+-------------------
+
 Update 1 host
 
 ```
-[all:vars]
-pkg_update=False
+  [all:vars]
+  pkg_update=False
 
-[test_hosts]
-host1.test.lab ansible_user=root ansible_host=192.168.1.1
-host2.test.lab ansible_user=root ansible_host=192.168.1.2 pkg_update=True
+  [test_hosts]
+  host1.test.lab ansible_user=root ansible_host=192.168.1.1
+  host2.test.lab ansible_user=root ansible_host=192.168.1.2 pkg_update=True
 
 ```
+
+License
+-------
+
+Apache License 2.0
+
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.
+

--- a/roles/update-host/tasks/main.yml
+++ b/roles/update-host/tasks/main.yml
@@ -1,29 +1,5 @@
 ---
 
-- name: "Update the host"
-  package:
-    name: "*"
-    state: latest
-  register: updated
-  when: 
-  - pkg_update|default(False) 
-
-- name: "Reboot the host"
-  shell: sleep 5 && shutdown -r now "Ansible Reboot of host"
-  async: 1
-  poll: 0
-  ignore_errors: true
-  when:
-  - updated.changed
-
-- name: "waiting for server to come back"
-  local_action: wait_for
-  args:
-    host: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
-    port: 22
-    delay: 15
-    timeout: 300
-    state: started
-  become: false
-  when:
-  - updated.changed
+- import_tasks: update-host.yml
+- import_tasks: reboot-host.yml
+- import_tasks: wait-for-host.yml 

--- a/roles/update-host/tasks/reboot-host.yml
+++ b/roles/update-host/tasks/reboot-host.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "Reboot the host"
+  shell: sleep 5 && shutdown -r now "Ansible Reboot of host"
+  async: 1
+  poll: 0
+  ignore_errors: true
+  when:
+    - host_updated.changed or force_host_reboot

--- a/roles/update-host/tasks/update-host.yml
+++ b/roles/update-host/tasks/update-host.yml
@@ -1,0 +1,10 @@
+---
+
+- name: "Update the host"
+  package:
+    name: "*"
+    state: latest
+  register: host_updated
+  when: 
+    - pkg_update|default(False) 
+

--- a/roles/update-host/tasks/wait-for-host.yml
+++ b/roles/update-host/tasks/wait-for-host.yml
@@ -1,0 +1,16 @@
+---
+
+- name: "Set the host to wait for"
+  set_fact:
+    update_host: "{{ (hostvars[inventory_hostname]['ansible_host'] is defined) |
+                      ternary(hostvars[inventory_hostname]['ansible_host'],
+                              hostvars[inventory_hostname]['ansible_ssh_host']) }}"
+
+- name: "Waiting for server to come back"
+  local_action: wait_for
+  args:
+    host: "{{ update_host }}"
+    port: 22
+    delay: 15
+    timeout: 300
+    state: started


### PR DESCRIPTION
### What does this PR do?
In cases where the update-host role is used with `ansible_become=True`, it may fail on the `wait_for_host` step if the localhost doesn't have sudo available. By breaking the `update-hosts` role into multiple files, the `import_role` module can be used with just portions of the role and hence control which one uses `ansible_become=True`. 

**Note:** The `become: False` parameter that used to be part of the role does not work in all cases, and hence this PR. 

### How should this be tested?
Use the role to update a target host, or use it as part of one of the playbooks that does - e.g.: the `provision-bastion` playbook.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
