### PR TITLE
Move rhsm role to use `yum` module

### DIFF
--- a/roles/rhsm/tasks/main.yml
+++ b/roles/rhsm/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "Install Satellite certificate (if applicable)"
-  command: "rpm -Uh --force http://{{ rhsm_server_hostname }}/pub/katello-ca-consumer-latest.noarch.rpm"
+  yum:
+    name: http://{{ rhsm_server_hostname }}/pub/katello-ca-consumer-latest.noarch.rpm
+    state: present
   when:
   - rhsm_server_hostname is defined
   - rhsm_server_hostname|trim != ''


### PR DESCRIPTION
### What does this PR do?
Move one play from rhsm role to install Satellite Katello CA using `yum` module instead of `rpm` command.

### How should this be tested?
Test the role as usual using instructions

### Is there a relevant Issue open for this?
No issues

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/infra-ansible
