### PR TITLE
Enhances to OpenStack inventory file

### DIFF
--- a/files/openstack.py
+++ b/files/openstack.py
@@ -147,7 +147,10 @@ def get_host_groups_from_cloud(inventory):
         if 'interface_ip' not in server:
             continue
         try:
-          if server["metadata"][os.environ['OS_INV_FILTER_KEY']] == os.environ['OS_INV_FILTER_VALUE']:
+          if os.environ.get('OS_INV_FILTER_KEY') is not None:
+            if os.environ['OS_INV_FILTER_KEY'] in server["metadata"] and server["metadata"][os.environ['OS_INV_FILTER_KEY']] == os.environ['OS_INV_FILTER_VALUE']:
+              firstpass[server['name']].append(server)
+          else:
             firstpass[server['name']].append(server)
         except:
           firstpass[server['name']].append(server)


### PR DESCRIPTION
### What does this PR do?
Enhanced logic for handling when `OS_INV_FILTER_KEY` and `OS_INV_FILTER_VALUE` are defined

### How should this be tested?
Provision OSP instances and define a metadata key/value pair in addition to `group` key

Set the `OS_INV_FILTER_KEY` and `OS_INV_FILTER_VALUE` environment variables associated to the key/value pair associated with the instance.

Only the instances containing the key/value pair should be returned in the associated group

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
No

### People to notify
cc: @redhat-cop/infra-ansible @oybed 
