### PR TITLE
updated tempdir variable to remove metadata directory

### DIFF
--- a/roles/dns/manage-dns-zones/tasks/named/process-one-zone.yml
+++ b/roles/dns/manage-dns-zones/tasks/named/process-one-zone.yml
@@ -37,7 +37,7 @@
     view_name: "{{ view.name }}"
   template:
     src: named/zone-config.j2
-    dest: "{{ tempdir }}/{{ view.name }}/0002-{{ zone.dns_domain }}.cfg"
+    dest: "{{ temp_dir }}/{{ view.name }}/0002-{{ zone.dns_domain }}.cfg"
     owner: named
     group: named
     mode: 0660

--- a/roles/dns/manage-dns-zones/tasks/named/process-views.yml
+++ b/roles/dns/manage-dns-zones/tasks/named/process-views.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure the final view directory exists
   file:
-    path: "{{ tempdir }}/view"
+    path: "{{ temp_dir }}/view"
     state: directory
 
 - include_tasks: process-zones.yml
@@ -13,7 +13,7 @@
 
 - name: Assemble the final view configuration
   assemble:
-    src: "{{ tempdir }}/view"
+    src: "{{ temp_dir }}/view"
     dest: "/etc/named/named.conf.view"
   notify: restart named
 

--- a/roles/dns/manage-dns-zones/tasks/named/process-zones.yml
+++ b/roles/dns/manage-dns-zones/tasks/named/process-zones.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure the view directory exists
   file:
-    path: "{{ tempdir }}/{{ view.name }}"
+    path: "{{ temp_dir }}/{{ view.name }}"
     state: directory
 
 - name: Set server config facts
@@ -18,14 +18,14 @@
     view_recursion: "{{ view_recursion | default(dns_data.named_global_config.recursion) }}"
   template:
     src: named/view-config-1.j2
-    dest: "{{ tempdir }}/{{ view.name }}/0001-{{ view.name }}.cfg"
+    dest: "{{ temp_dir }}/{{ view.name }}/0001-{{ view.name }}.cfg"
     owner: named
     group: named
     mode: 0660
   when:
     - view.state|default('present') == 'present'
 
-- name: "Initialize flags"
+- name: Initialize flags
   set_fact:
     processed_zones: False
 
@@ -40,7 +40,7 @@
     view_forwarders: "{{ view.default_forwarders | default(['127.0.0.1']) }}"
   template:
     src: named/view-config-2.j2
-    dest: "{{ tempdir }}/{{ view.name }}/0003-{{ view.name }}.cfg"
+    dest: "{{ temp_dir }}/{{ view.name }}/0003-{{ view.name }}.cfg"
     owner: named
     group: named
     mode: 0660
@@ -50,15 +50,15 @@
 
 - name: Assemble the complete view file
   assemble:
-    src: "{{ tempdir }}/{{ view.name }}"
-    dest: "{{ tempdir }}/view/{{ view.name }}.cfg"
+    src: "{{ temp_dir }}/{{ view.name }}"
+    dest: "{{ temp_dir }}/view/{{ view.name }}.cfg"
   when:
     - processed_zones|bool == True
     - view.state|default('present') == 'present'
 
 - name: Remove temporary view if no zones were processed
   file:
-    path: "{{ tempdir }}/{{ view.name }}"
+    path: "{{ temp_dir }}/{{ view.name }}"
     state: absent
   when:
     - processed_zones|bool == False


### PR DESCRIPTION
### What does this PR do?
In the role dns/config-dns-server several files were using the variable {{ tempdir }} instead of {{ temp_dir }}. {{ tempdir }} contains metadata along with the name of a temp directory, while temp_dir is just the name of the directory. This caused a directory to be created with a string consisting of all the metadata output. I updated the appropriate locations to use {{ temp_dir }} in this pr. 

### How should this be tested?
run command `ansible-playbook playbook/provision-dns-server/configure-dns-server`
verify that a directory by the name ` {'stderr_lines': [], u'changed': True, u'end': u'2018-06-26 21:00:50.439428', 'failed': False, u'stdout': u'` is not created under `playbook/provision-dns-server/`


### People to notify
cc: @oybed 
