### PR TITLE
add support for tower certificate and key

### DIFF
--- a/roles/ansible/tower/config-ansibletower/tasks/install.yml
+++ b/roles/ansible/tower/config-ansibletower/tasks/install.yml
@@ -60,3 +60,14 @@
   shell: curl {{ oc_client_download_url }} | tar -C /bin/ -xzf -
   args:
     warn: False
+
+- name: "Copy custom Tower SSL certificate and Key"
+  block:
+    - copy:
+        src: "{{ tower_custom_ssl_certificate.cert }}"
+        dest: /etc/tower/tower.cert
+
+    - copy:
+        src: "{{ tower_custom_ssl_certificate.key }}"
+        dest: /etc/tower/tower.key
+  when: tower_custom_ssl_certificate is defined  

--- a/roles/ansible/tower/config-ansibletower/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/config-ansibletower/tests/inventory/group_vars/tower.yml
@@ -7,6 +7,11 @@ rabbitmq_password: "rabbitmq_password01"
 # Update this to a valid tower license file
 #tower_license_file: "{{ inventory_dir }}/../files/tower-license.json"
 
+# Update this to a valid tower cert and key 
+#tower_custom_ssl_certificate:
+#   cert: "{{ inventory_dir }}/../certs/tower.cert"
+#   key: "{{ inventory_dir }}/../certs/tower.key"
+
 # Overall flag to indicate if LDAP should be configured or not
 ldap_config: False
 


### PR DESCRIPTION
### What does this PR do?
This PR adds support for providing tower certificates and key

### How should this be tested?
`cd infra-ansible/roles/ansible/tower/config-ansibletower/tests`
run the `test inventory`



### People to notify
cc: @redhat-cop/infra-ansible @oybed @logandonley 
