### PR TITLE
Fixing bug with download URL variable + quite up warnings

### DIFF
--- a/roles/ansible/tower/config-ansibletower/tasks/install.yml
+++ b/roles/ansible/tower/config-ansibletower/tasks/install.yml
@@ -15,7 +15,9 @@
   register: installer_dir
 
 - name: "Download & Unpack Ansible Tower installer"
-  shell: curl {{ default_ansible_tower_url }} | tar xzf -
+  shell: curl {{ ansible_tower_download_url }} | tar xzf -
+  args:
+    warn: False
   when: not installer_dir.stat.exists
 
 - name: "Set up the Ansible Tower inventory"
@@ -56,3 +58,5 @@
 
 - name: "Download and Install the 'oc' client for OpenShift interactions"
   shell: curl {{ oc_client_download_url }} | tar -C /bin/ -xzf -
+  args:
+    warn: False


### PR DESCRIPTION
### What does this PR do?
Fixing the `ansible_tower_download_url` variable name + adding flags to quite up Ansible warnings as using the `shell` command is the best option for these operations.

### How should this be tested?
Perform an install of Ansible Tower utilizing the `infra-ansible` automation

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @logandonley @procrypt
