### PR TITLE
Update example inventory to include default_forwarder and print_dns_keys

### DIFF
--- a/roles/dns/README.md
+++ b/roles/dns/README.md
@@ -56,6 +56,8 @@ Example Inventory
 ----------------
 
 ```
+print_dns_keys: True
+
 dns_data:
   named_global_config:
     recursion: 'no'
@@ -68,6 +70,8 @@ dns_data:
         recursion: 'yes'
         acl_entry:
           - 192.168.10.0/24
+      default_forwarders:
+      - 8.8.8.8
       zones:
         - dns_domain: first.example.com
           state: present


### PR DESCRIPTION
### What does this PR do?
This adds an example of using the default_forwarder to the example inventory. It also highlights using print_dns_keys to output the dns key that is generated by the run for each zone.
