### PR TITLE
Update config-vnc-server role to pull appropriate python firewall pac…

### DIFF
--- a/roles/config-vnc-server/tasks/prereq.yml
+++ b/roles/config-vnc-server/tasks/prereq.yml
@@ -1,12 +1,18 @@
 ---
 
+- name: 'Determine required python firewall package'
+  set_fact:
+    python_firewall_package="python3-firewall"
+  when:
+  - ansible_python_version is match("3.*")
+
 - name: 'Install required packages'
   package:
     name: '{{ item }}'
     state: installed
   with_items:
   - firewalld
-  - python-firewall
+  - "{{ python_firewall_package | default('python-firewall') }}"
 
 - name: 'Ensure firewalld is running'
   service:


### PR DESCRIPTION

### What does this PR do?
This PR pulls the appropriate python firewall package depending on what version of the python interpreter is being used. During use on Fedora 28, it was noted that `python-firewall` was no longer available. To get around this, the official answer appears to be to utilize the python3 package. To do this, you just need to set the `ansible_python_interpreter` to use python3. The modified step will then recognize that the interpreter being used is python3 and then sets the package to be pulled to `python3-firewall`. If this isn't set, it will default to continue the use of python-firewall.

Details can be seen here for solution to python3 only hosts:

https://github.com/ansible/ansible/commit/a8bdcd19f0961782f2c9ba065540bd44bcc05732

### How should this be tested?

1. Spin up a bastion with Fedora < 28. This will pick up and use the `python-firewall` package as expected
2. Spin up a bastion with Fedora 28. You will then need to add the following to yours hosts file so that it picks up the appropriate hosts var to set the interpreter. It will then pull the `python3-firewall` package instead of the default.

```
[bastion:vars]
ansible_python_interpreter=/usr/bin/python3
```

### People to notify
cc: @oybed @logandonley @makentenza 
