### PR TITLE
Fixing typo in var name

### DIFF
--- a/roles/load-balancers/generate-haproxy-config/templates/lb_backend.j2
+++ b/roles/load-balancers/generate-haproxy-config/templates/lb_backend.j2
@@ -23,7 +23,7 @@ backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }}
 
 {% for backend in entry.backends %}
 {% set lb_backend_host = backend.name | default(backend.host) %}
-{% set lb_backend_port = backend.port | default(entry.port) %}
+{% set lb_backend_port = backend.port | default(entry.lb_match_port) %}
 
 {% if lb_ssl_enabled %}
     server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} check


### PR DESCRIPTION
### What does this PR do?
Fixing the typo in a var name. Due to last minute variable re-naming, one was missed. 

### How should this be tested?
Run through the automation with a valid inventory - including an entry that looks similar to the following:

```
 :
  - lb_match_fqdn: hello.world.com
    lb_match_port: 80
    backends:
    - host: my-hello-world.com
 :
```

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
