### PR TITLE
Moving away from 'hardcoded' localhost + adding some docs info

### DIFF
--- a/inventory/bastion/group_vars/all.yml
+++ b/inventory/bastion/group_vars/all.yml
@@ -42,7 +42,7 @@ osp_instances:
 - name: "bastion-bob0"
   meta:
     group: bastion
-  image: "Fedora-Cloud-Base-27-1.6.x86_64"
+  image: "Fedora-Cloud-Base-28-1.1.x86_64"
   key_name: "bob-laptop"
   flavor: "m1.medium"
   network: "bob-default"

--- a/inventory/bastion/group_vars/bastion.yml
+++ b/inventory/bastion/group_vars/bastion.yml
@@ -1,15 +1,25 @@
 ---
+
+# Starting with Fedora 28, the python interpreter needs to be Python3 
+# for various packages to work - including prereq for firewalld
+ansible_python_interpreter: /usr/bin/python3
+
 ansible_user: fedora
 ansible_become: True
+
 main_user: bob
+
 ipa_client_install: True
 ipa_domain: ipa-realm.example.com
 ipa_automount_location: userhome
 ipa_username: bob
+
 docker_install: True
 docker_compose_install: True
 docker_username: bob
+
 vnc_server_install: False
+
 list_of_packages_to_install:
 - git
 - screen

--- a/inventory/bastion/host_vars/localhost.yml
+++ b/inventory/bastion/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_connection: local

--- a/inventory/bastion/hosts
+++ b/inventory/bastion/hosts
@@ -1,3 +1,7 @@
+
+[osp-provisioner]
+localhost
+
 [bastion]
 
 [osp_instances:children]

--- a/inventory/dns-server/host_vars/localhost.yml
+++ b/inventory/dns-server/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_connection: local

--- a/inventory/dns-server/hosts
+++ b/inventory/dns-server/hosts
@@ -1,4 +1,6 @@
 
+[osp-provisioner]
+localhost
 
 [dns-server:children]
 osp_instances

--- a/inventory/idm/hosts
+++ b/inventory/idm/hosts
@@ -1,3 +1,7 @@
+
+[osp-provisioner]
+localhost
+
 [idm]
 
 [dns-server]

--- a/inventory/satellite_server/host_vars/localhost.yml
+++ b/inventory/satellite_server/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_connection: local

--- a/inventory/satellite_server/hosts
+++ b/inventory/satellite_server/hosts
@@ -1,4 +1,6 @@
 
+[osp-provisioner]
+localhost
 
 [satellite_servers:children]
 osp_instances

--- a/playbooks/osp/delete-osp-instance.yml
+++ b/playbooks/osp/delete-osp-instance.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Delete Instance(s)
-  hosts: localhost
+  hosts: osp-provisioner
   vars:
     osp_resource_state: absent 
   roles:

--- a/playbooks/osp/manage-user-network.yml
+++ b/playbooks/osp/manage-user-network.yml
@@ -3,6 +3,6 @@
 # See the roles README for detailed info on inventory requirements.
 # https://github.com/redhat-cop/infra-ansible/blob/master/roles/osp/admin-network/README.md
 
-- hosts: localhost
+- hosts: osp-provisioner
   roles:
   - osp/admin-network

--- a/playbooks/osp/provision-osp-instance.yml
+++ b/playbooks/osp/provision-osp-instance.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Provision Instance(s)
-  hosts: localhost
+  hosts: osp-provisioner
   roles:
   - role: osp/admin-volume
   - role: osp/admin-sec-group
   - role: osp/admin-instance
 
 - name: Refresh Server inventory
-  hosts: localhost
+  hosts: osp-provisioner
   gather_facts: False
   tasks:
   - meta: refresh_inventory

--- a/playbooks/provision-bastion/README.md
+++ b/playbooks/provision-bastion/README.md
@@ -45,3 +45,5 @@ How to run the playbook may depend on the options selected. However, below is an
 |vnc_server_install|Set to `True` if you'd like to enable a VNC server on this host for graphical access to the host|
 |list_of_packages_to_install|List of additional packages (RPMs) to be installed at the end of the bastion host preparation, e.g.: `['git', 'vim']`|
 |timezone| `Optional` Timezone of the Bastion ie `America/Denver`|
+|ansible_python_interpreter| `Optional` Required to be set to `/usr/bin/python3` when using systems like Fedora 28 where certain packages are dependent on python3| 
+


### PR DESCRIPTION
### What does this PR do?
This PR makes changes to some playbooks to move aware from the hardcoded `localhost` and hence introduces a provisioner definition instead - in this particular PR this is `osp-provisioner` as it only deals with OSP related playbooks. 

It also adds the newly required requirement for `python3` to some of the sample inventories based on Fedora 28. 

### How should this be tested?
Run the playbooks changed to test them.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @tylerauerbeck @logandonley 
