### PR TITLE
Enhancing rhsm role to allow for force-registration

### DIFF
--- a/roles/rhsm/README.md
+++ b/roles/rhsm/README.md
@@ -1,0 +1,81 @@
+Role Name
+=========
+
+This role is used to manage Red Hat subscriptions of the target hosts.
+
+Requirements
+------------
+
+1. A valid Red Hat subscription, either directly with redhat.com or through the use of Red Hat Satellite
+
+
+Role Variables
+--------------
+
+See `Example Inventory` below for more specific details. At a high level, the following variables need to be defined:
+
+| variable | info | required? |
+|:--------:|:----:|:---------:|
+|rhsm_username|Username used to register to access.redhat.com|yes if username/password is used|
+|rhsm_password|Password used to register to access.redhat.com|yes if username/password is used|
+|rhsm_server_hostname|The Satellite hostname/FQDN used for registration|yes if Satellite registration is used|
+|rhsm_activationkey|The Satellite activationkey used for registration|yes if Satellite registration is used|
+|rhsm_org_id|The Satellite organization ID used for registration|yes if Satellite registration is used|
+|rhsm_pool|The subscription pool name used for registration|no|
+|rhsm_repos|A list of repositories to enable|no|
+|rhsm_force_register|Set to 'yes' to force a unregister/clean + re-registration|no|
+
+
+Dependencies
+------------
+
+None
+
+
+Example Playbook
+----------------
+
+```
+    - hosts: servers
+      roles:
+      - role: rhsm
+```
+
+
+Example Inventory
+----------------
+
+
+When using Satellite:
+
+```
+rhsm_server_hostname: 'sat.example.com'
+rhsm_org_id: 'my-org'
+rhsm_activationkey: 'my-org-key'
+
+rhsm_repos:
+ - "rhel-7-server-rpms"
+ - "rhel-7-server-extras-rpms"
+```
+
+When using access.redhat.com:
+
+```
+rhsm_username: 'my-username'
+rhsm_password: 'my-password'
+
+rhsm_repos:
+ - "rhel-7-server-rpms"
+ - "rhel-7-server-extras-rpms"
+```
+
+
+License
+-------
+
+Apache License 2.0
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/rhsm/tasks/main.yml
+++ b/roles/rhsm/tasks/main.yml
@@ -1,7 +1,19 @@
 ---
 
+# Need to use the 'command' module for this task since the "redhat_subscription" module
+# won't do a full "clean" when using the "state: absent" option
+- name: 'Unregister the system if already registered - if this is a force re-registration'
+  command: 'subscription-manager clean'
+  when:
+  - (rhsm_force_register|default('no'))|lower == 'yes'
+
+# Need to use the 'command' module for this task since the "yum" module
+# won't honor an "upgrade" of the RPM in case where the source server changed. 
+# - note the 'warn: False' set because of this situation
 - name: "Install Satellite certificate (if applicable)"
   command: "rpm -Uh --force http://{{ rhsm_server_hostname }}/pub/katello-ca-consumer-latest.noarch.rpm"
+  args:
+    warn: False
   when:
   - rhsm_server_hostname is defined
   - rhsm_server_hostname|trim != ''
@@ -15,6 +27,7 @@
     server_hostname: "{{ rhsm_server_hostname | default(omit) }}"
     activationkey: "{{ rhsm_activationkey | default(omit) }}"
     org_id: "{{ rhsm_org_id | default(omit) }}"
+    force_register: "{{ rhsm_force_register | default(omit) }}"
 
 - name: "Obtain currently enabled repos"
   shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'


### PR DESCRIPTION
### What does this PR do?
Updating the `rhsm` role to allow for a successful unregistration / re-registration - for example when hosts are moved from one Satellite to another. 

Also adding in comments and quieting up the command module runs that showed warnings re: using `yum` instead of `command` - related to PR #171 

### How should this be tested?
1. Create an inventory that registers a RHEL host to a Satellite server. 
1. Validate successful registration 
1. Update the inventory to point to a second/different Satellite server and re-run the playbook
1. Observe that the re-registration is failing.
1. Supply the `rhsm_force_register=yes` set as part of the re-run
1. Validate successful re-registration to new Satellite server

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
#171 

### People to notify
cc: @redhat-cop/infra-ansible @tylerauerbeck @logandonley 
