### PR TITLE
Adding missing SELinux dependency

### DIFF
--- a/roles/load-balancers/manage-haproxy/tasks/install.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/install.yml
@@ -12,6 +12,7 @@
     - firewalld
     - python-firewall
     - libsemanage-python
+    - policycoreutils-python
     notify: 'enable and start service(s)'
 
   - name: 'Start firewalld'


### PR DESCRIPTION
### What does this PR do?
With the latest changes for the HAproxy LB role, there's an additional RPM dependency needed for the SElinux management. This PR adds the RPM

### How should this be tested?
Run the complete playbook on a "fresh" VM - i.e.:

```
ansible-playbook -i inventory playbooks/manage-lb/lb-vms.yml -t install
```

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
