### PR TITLE
Allow for custom vnc password

### DIFF
--- a/inventory/bastion/group_vars/all.yml
+++ b/inventory/bastion/group_vars/all.yml
@@ -31,6 +31,14 @@ osp_security_groups:
     port_range_max: 22
     direction: ingress
     remote_ip_prefix: 0.0.0.0/0
+- name: "vnc-sec-group"
+  description: "My VNC Sec Group"
+  rules:
+  - protocol: tcp
+    port_range_min: 5901
+    port_range_max: 5901
+    direction: ingress
+    remote_ip_prefix: 0.0.0.0/0
 - name: "icmp-sec-group"
   description: "ICMP Security Group"
   rules:
@@ -49,3 +57,4 @@ osp_instances:
   security_groups:
   - ssh-sec-group
   - icmp-sec-group
+  - vnc-sec-group

--- a/playbooks/provision-bastion/README.md
+++ b/playbooks/provision-bastion/README.md
@@ -45,5 +45,6 @@ How to run the playbook may depend on the options selected. However, below is an
 |vnc_server_install|Set to `True` if you'd like to enable a VNC server on this host for graphical access to the host|
 |list_of_packages_to_install|List of additional packages (RPMs) to be installed at the end of the bastion host preparation, e.g.: `['git', 'vim']`|
 |timezone| `Optional` Timezone of the Bastion ie `America/Denver`|
-|ansible_python_interpreter| `Optional` Required to be set to `/usr/bin/python3` when using systems like Fedora 28 where certain packages are dependent on python3| 
+|ansible_python_interpreter| `Optional` Required to be set to `/usr/bin/python3` when using systems like Fedora 28 where certain packages are dependent on python3|
+|vnc_password| `Optional` Set VNC password to a specific value instead of accepting the default| 
 

--- a/roles/config-vnc-server/tasks/vnc-server.yml
+++ b/roles/config-vnc-server/tasks/vnc-server.yml
@@ -20,8 +20,8 @@
     path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
   register: passwd_info 
 
-- name: "Set a default vnc password (use 'vncpasswd' to change)"
-  shell: "echo vncpasswd01 | vncpasswd -f > {{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
+- name: "Set a vnc password"
+  shell: "echo {{ vnc_password | default('vncpasswd01') }} | vncpasswd -f > {{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
   when: passwd_info.stat.exists == False
 
 - name: "Ensure correct ownership of the vnc password file"


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to customize and provide the password used to authenticate with the vnc server. It also adds the vnc security group required to allow access to the vnc server to the sample inventory.

### How should this be tested?

This can be tested by spinning up a bastion server and specifying `vnc_password: your_desired_password` in your `bastion.yml` inventory. If specified, this will set your the vnc password to the one you have chosen, otherwise it will configure it using the default value.

### Is there a relevant Issue open for this?
#40 

### People to notify
cc: @redhat-cop/infra-ansible
