### PR TITLE
path fix while mounting iso

### DIFF
--- a/roles/virt-install/tasks/virt-install.yml
+++ b/roles/virt-install/tasks/virt-install.yml
@@ -41,7 +41,7 @@
 
 - name: "Mount ISO to serv it up with http"
   mount:
-    src: "{{ virtinstall_iso }}"
+    src: "/{{ virtinstall_iso }}"
     path: "{{ http_mount.path }}"
     opts: loop
     fstype: iso9660


### PR DESCRIPTION
### What does this PR do?
The path to mount iso is broken.
current path `tmp/<iso>`
updated path `/tmp/<iso>`

### People to notify
cc: @redhat-cop/infra-ansible @oybed 