### PR TITLE
Virt-Role missing package for fedora

### DIFF
--- a/roles/virt-install/tasks/prereq.yml
+++ b/roles/virt-install/tasks/prereq.yml
@@ -7,6 +7,7 @@
   with_items:
   - virt-install
   - httpd
+  - libselinux-python
 
 - name: 'Enable and start libvirtd'
   service:


### PR DESCRIPTION
### What does this PR do?
Installs  `libselinux-python` as this package is required to run the role on Fedora.

### People to notify
cc: @redhat-cop/infra-ansible @oybed 
