### PR TITLE
bugix for multinode quay install

### DIFF
--- a/roles/config-quay-enterprise/tasks/complete_setup.yml
+++ b/roles/config-quay-enterprise/tasks/complete_setup.yml
@@ -4,8 +4,12 @@
   set_fact:
     tmp_setup_file_location: /tmp/quay
 
-- name: Flush Handlers
-  meta: flush_handlers
+- name: Start quay on one node
+  systemd:
+    name: "{{ quay_name }}"
+    enabled: yes
+    state: restarted
+    daemon_reload: yes
 
 - name: Hit Quay Setup Endpoint
   uri:

--- a/roles/config-quay-enterprise/tasks/main.yml
+++ b/roles/config-quay-enterprise/tasks/main.yml
@@ -128,6 +128,13 @@
 - name: Include firewall tasks
   include_tasks: firewall.yml
 
+- name: Stop quay to complete setup
+  systemd:
+    name: "{{ quay_name }}"
+    state: stopped
+
 - name: Setup Initial User and Configuration
   include_tasks: complete_setup.yml
   when: not quay_config_stat_result.stat.exists and quay_superuser_username is defined and quay_superuser_username|trim != "" and quay_superuser_password is defined and quay_superuser_password|trim != "" and quay_superuser_email is defined and quay_superuser_email|trim != "" 
+  run_once: true
+  notify: Restart quay service


### PR DESCRIPTION
### What does this PR do?
Updates the quay installer so that the complete_setup.yml tasks only run with one quay node active. This solves the bug where superuser creation would occasionally fail on multinode installations

### Is there a relevant Issue open for this?
redhat-cop#224

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
