### PR TITLE
Adding selinux relabel option for when selinux goes from disabled to …

### DIFF
--- a/roles/config-selinux/README.md
+++ b/roles/config-selinux/README.md
@@ -13,6 +13,8 @@ Role Variables
 
 - target_state: The SELinux state
 - target_policy: The targeted SELinux policy
+- selinux_relabel: Whether to run restorecon
+- selinux_relabel_dir: The directory to recursively relabel with restorecon
 
 
 Dependencies
@@ -26,6 +28,13 @@ Example Playbook
     - hosts: servers
       roles:
          - role: config-selinux
+
+    - hosts: servers
+      roles:
+         - role: config-selinux
+           selinux_relabel: yes
+           selinux_relabel_dir: /etc
+
 
 License
 -------

--- a/roles/config-selinux/tasks/main.yml
+++ b/roles/config-selinux/tasks/main.yml
@@ -7,5 +7,5 @@
 
 - name: "Relabel SElinux contexts"
   command: "restorecon -r {{ selinux_relabel_dir | default('/') }}"
-  when: selinux_relabel | default('false') | bool
+  when: selinux_relabel | default('no') | bool
 

--- a/roles/config-selinux/tasks/main.yml
+++ b/roles/config-selinux/tasks/main.yml
@@ -4,3 +4,8 @@
   selinux:
     state: "{{ target_state | default('enforcing') }}"
     policy: "{{ (target_state == 'disabled') | ternary(omit, target_policy) }}"
+
+- name: "Relabel SElinux contexts"
+  command: "restorecon -r {{ selinux_relabel_dir | default('/') }}"
+  when: selinux_relabel | default('false') | bool
+


### PR DESCRIPTION
### What does this PR do?
Adding option to trigger a `restorecon` task on a certain directory defaults to '/'. This covers the case when selinux goes from disabled to enforcing, and a relabelling of SElinux contexts is required.

### How should this be tested?
disable selinux and remove contexts from a certain directory(reboot potentially required)

`cd infra-ansible/roles/config-selinux/tests/`
add `selinux_relabel: yes` or `selinux_relabel: no`
`$ ansible-playbook -i inventory/hosts test.yml -K --become`

This playbook will enable selinux as well as relabel `/` or `selinux_relabel_dir` recursively.

### Is there a relevant Issue open for this?
https://github.com/redhat-cop/casl-ansible/issues/292
resolves #292

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/infra-ansible
