### PR TITLE
manage-jira: Update broken template variable and documentation

### DIFF
--- a/roles/manage-jira/README.md
+++ b/roles/manage-jira/README.md
@@ -92,7 +92,7 @@ atlassian:
 ```
 
 *Note:
-This role  assumes that three groups "project_lead", "project_team_member" and "project_viewer" have already been created. This can be done using the [manage-atlassian-users](https://github.com/redhat-cop/infra-ansible/tree/master/roles/user-management/manage-atlassian-users) role *
+This role  assumes that three groups "project_lead", "project_team_member" and "project_viewer" have already been created. This can be done using the [manage-atlassian-users](../user-management/manage-atlassian-users) role *
 
 #### This role does three things
 1.  Creates a Project Category

--- a/roles/manage-jira/README.md
+++ b/roles/manage-jira/README.md
@@ -38,11 +38,11 @@ curl --user email@example.com:<api_token> \
 
 | Variable | Description | Required | Defaults |
 |:--------:|:-----------:|:--------:|:--------:|
-|**jira.url**| url of atlassian server | yes | N/A |
-|**jira.username**| username of altassion server | yes | N/A |
-|**jira.password**| password of altassion server | yes | N/A |
-|**jira.jira-admin**| jira admin group to add to the permission scheme | yes| N/A |
-|**jira.lead**| The username of the project lead | yes | N/A |
+|**jira.url**| url of Atlassian server | yes | N/A |
+|**jira.username**| username of Atlassian server | yes | N/A |
+|**jira.password**| password of Atlassian server | yes | N/A |
+|**jira.jira-admin**| Jira admin group to add to the permission scheme | yes| N/A |
+|**jira.lead**| The username of the project lead. This is just the username, not the email address of the user | yes | N/A |
 |**jira.core_team**| team to give admin access | yes | N/A |
 |**project.name**| project name | yes | N/A |
 |**project.key**| Project keys must be unique and start with an uppercase letter followed by one or more uppercase alphanumeric characters. Required when creating a project | yes | N/A |
@@ -92,7 +92,7 @@ atlassian:
 ```
 
 *Note:
-This role  assumes that three groups "project_lead", "project_team_member" and "project_viewer" have already been created.*
+This role  assumes that three groups "project_lead", "project_team_member" and "project_viewer" have already been created. This can be done using the [manage-atlassian-users](https://github.com/redhat-cop/infra-ansible/tree/master/roles/user-management/manage-atlassian-users) role *
 
 #### This role does three things
 1.  Creates a Project Category

--- a/roles/manage-jira/templates/permissionScheme.json.j2
+++ b/roles/manage-jira/templates/permissionScheme.json.j2
@@ -267,7 +267,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "ASSIGNABLE_USER"
      },
@@ -275,7 +275,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "ASSIGN_ISSUES"
      },
@@ -283,7 +283,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "BROWSE_PROJECTS"
      },
@@ -291,7 +291,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "CLOSE_ISSUES"
      },
@@ -299,7 +299,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "CREATE_ISSUES"
      },
@@ -307,7 +307,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "DELETE_ISSUES"
      },
@@ -315,7 +315,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "EDIT_ISSUES"
      },
@@ -323,7 +323,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "LINK_ISSUES"
      },
@@ -331,7 +331,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "MOVE_ISSUES"
      },
@@ -339,7 +339,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "RESOLVE_ISSUES"
      },
@@ -347,7 +347,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "SCHEDULE_ISSUES"
      },
@@ -355,7 +355,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "TRANSITION_ISSUES"
      },
@@ -363,7 +363,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "ADD_COMMENTS"
      },
@@ -371,7 +371,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "DELETE_OWN_COMMENTS"
      },
@@ -379,7 +379,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "EDIT_OWN_COMMENTS"
      },
@@ -387,7 +387,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "CREATE_ATTACHMENTS"
      },
@@ -395,7 +395,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "DELETE_OWN_ATTACHMENTS"
      },
@@ -403,7 +403,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "DELETE_OWN_WORKLOGS"
      },
@@ -411,7 +411,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "EDIT_OWN_WORKLOGS"
      },
@@ -419,7 +419,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "VIEW_DEV_TOOLS"
      },
@@ -427,7 +427,7 @@
      {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "VIEW_READONLY_WORKFLOW"
      },
@@ -435,7 +435,7 @@
     {
        "holder": {
          "type": "group",
-         "parameter": "atlassian.jira.core_team"
+         "parameter": "{{ atlassian.jira.core_team }}"
        },
        "permission": "WORK_ON_ISSUES"
      },


### PR DESCRIPTION
### What does this PR do?
This fixes the issue of the template not being able to correctly pick up the `atlassian.jira.core_team` variable in the appropriate template. After adding the braces, this issue no longer occurs.

### How should this be tested?
Use the test inventory (with appropriate values) and this will now run without issue.

### People to notify
cc: @redhat-cop/infra-ansible
