### PR TITLE
Allow Satellite based registration with activationkey and org_id

### DIFF
--- a/playbooks/prep.yml
+++ b/playbooks/prep.yml
@@ -3,17 +3,21 @@
 - name: 'Configure RHSM usernames/passwords'
   hosts: localhost
   tasks: 
-  - pause:
-      prompt: 'Please enter your Red Hat Subscription username'
-    register: username
-  - set_fact:
-      rhsm_username: "{{ username.user_input }}"
-  - pause:
-      prompt: 'Please enter your Red Hat Subscription password'
-    no_log: True
-    register: password
-  - set_fact:
-      rhsm_password: "{{ password.user_input }}"
-    no_log: True
-  tags:
-  - configure_rhsm
+  - block:  
+    - pause:
+        prompt: 'Please enter your Red Hat Subscription username'
+      register: username
+    - set_fact:
+        rhsm_username: "{{ username.user_input }}"
+    - pause:
+        prompt: 'Please enter your Red Hat Subscription password'
+      no_log: True
+      register: password
+    - set_fact:
+        rhsm_password: "{{ password.user_input }}"
+      no_log: True
+    tags:
+    - configure_rhsm
+    when:
+    - rhsm_activationkey is undefined 
+    - rhsm_org_id is undefined 

--- a/playbooks/provision-dns-server/subscribe-rhel.yml
+++ b/playbooks/provision-dns-server/subscribe-rhel.yml
@@ -2,8 +2,8 @@
 
 - name: "Subscribe RHEL based instances" 
   vars:
-    rhsm_username: "{{ hostvars['localhost'].rhsm_username }}"
-    rhsm_password: "{{ hostvars['localhost'].rhsm_password }}"
+    rhsm_username: "{{ hostvars['localhost'].rhsm_username|default(omit) }}"
+    rhsm_password: "{{ hostvars['localhost'].rhsm_password|default(omit) }}"
   include_role: 
     name: rhsm
 

--- a/playbooks/provision-satellite-server/main.yml
+++ b/playbooks/provision-satellite-server/main.yml
@@ -15,8 +15,8 @@
 
 - hosts: satellite_servers
   vars:
-    rhsm_username: "{{ hostvars['localhost'].rhsm_username }}"
-    rhsm_password: "{{ hostvars['localhost'].rhsm_password }}"
+    rhsm_username: "{{ hostvars['localhost'].rhsm_username|default(omit) }}"
+    rhsm_password: "{{ hostvars['localhost'].rhsm_password|default(omit) }}"
   roles: 
   - role: rhsm
   - role: update-host

--- a/playbooks/rhsm.yml
+++ b/playbooks/rhsm.yml
@@ -6,8 +6,8 @@
 
 - hosts: rhsm_hosts
   vars:
-    rhsm_username: "{{ hostvars['localhost'].rhsm_username | default(omit) }}"
-    rhsm_password: "{{ hostvars['localhost'].rhsm_password | default(omit) }}"
+    rhsm_username: "{{ hostvars['localhost'].rhsm_username|default(omit) }}"
+    rhsm_password: "{{ hostvars['localhost'].rhsm_password|default(omit) }}"
   roles: 
   - role: rhsm
     no_log: True

--- a/playbooks/vm.yml
+++ b/playbooks/vm.yml
@@ -24,8 +24,8 @@
 - name: 'Subscribe the VMs to RHSM'
   hosts: infra_vms
   vars:
-    rhsm_username: "{{ hostvars['localhost'].rhsm_username }}"
-    rhsm_password: "{{ hostvars['localhost'].rhsm_password }}"
+    rhsm_username: "{{ hostvars['localhost'].rhsm_username|default(omit) }}"
+    rhsm_password: "{{ hostvars['localhost'].rhsm_password|default(omit) }}"
   roles:
   - role: rhsm
   tags:


### PR DESCRIPTION
The rhsm role has support for activation via satellite with activationkey
and org_id, which is the preferred method.  However several of the playbooks
that call the rhsm role still required username and password, which
is not needed when registering to satellite with activationkey and org_id.

### What does this PR do?
This change adds the ability to perform registration to RH CDN or Satellite with activationkey/org_id instead of username/password.  This adds flexibility; now either username/password or activationkey/org_id can be specified.

### How should this be tested?
Test registration with either:
- rhsm_username & rhsm_password
or
- rhsm_activationkey & rhsm_org_id

### Is there a relevant Issue open for this?
resolves #256

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
