### PR TITLE
Updated mail notification for Ansible 2.5/2.6

### DIFF
--- a/playbooks/notifications/email-notify-group-of-users.yml
+++ b/playbooks/notifications/email-notify-group-of-users.yml
@@ -1,0 +1,10 @@
+---
+
+- name: "Obtain list of users to e-mail"
+  hosts: mail-host
+  gather_facts: no
+  tasks:
+  - include_role:
+      name: roles/user-management/list-users-by-group
+
+- import_playbook: email-notify-list-of-users.yml

--- a/playbooks/notifications/email-notify-list-of-users.yml
+++ b/playbooks/notifications/email-notify-list-of-users.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "Send HTML e-mail message to a list of users who are members of a group"
+- name: "Send HTML e-mail message (base on MD) to a list of users"
   hosts: mail-host
   gather_facts: no
   tasks:
@@ -8,17 +8,13 @@
       file: "{{ email_content_file }}"
   - include_role:
       name: notifications/md-to-html
-      vars:
-        markdown_content: "{{ body }}"
+    vars:
+      markdown_content: "{{ body }}"
   - set_fact:
-      mail:
-        subject: "{{ subject }}"
-        body: "{{ md_to_html.html_body_message }}"
-  - include_role:
-      name: roles/user-management/list-users-by-group
+      mail: "{{ mail | combine({ 'subject': subject, 'body': md_to_html.html_body_message }) }}"
   - set_fact:
-      list_of_mail_to: "{{ list_of_mail_to | default([]) }} + [ {{ item.email }} ]"
-    with_items: 
+      list_of_mail_to: "{{ list_of_mail_to | default([]) }} + [ '{{ item.email }}' ]"
+    with_items:
     - "{{ list_of_users }}"
   - include_role:
       name: notifications/send-email

--- a/playbooks/notifications/email-notify-list-of-users.yml
+++ b/playbooks/notifications/email-notify-list-of-users.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "Send HTML e-mail message (base on MD) to a list of users"
+- name: "Send HTML e-mail message (based on MD) to a list of users"
   hosts: mail-host
   gather_facts: no
   tasks:

--- a/roles/notifications/send-email/README.md
+++ b/roles/notifications/send-email/README.md
@@ -13,7 +13,7 @@ None
 
 ## Role Variables
 
-**_Note:_** These variables are listed as part of the `mail` dict
+**_Note:_** These variables are listed as part of the `mail` dictionary
 
 | Variable | Description | Required | Other Info |
 |:--------:|:-----------:|:--------:|:----------:|
@@ -21,11 +21,11 @@ None
 |**mail.port**| SMTP server Port|no|Per Ansible module, defaults to `25`|
 |**mail.username**|SMTP Server login if required|no||
 |**mail.password**|SMTP Server password if required|no||
-|**mail.to**| To Address|No|**_Tip:_** Can be a comma separated list of e-mail addresses|
-|**mail.cc**| CC Address|No|**_Tip:_** Can be a comma separated list of e-mail addresses| 
-|**mail.bcc**| BCC Address|No |**_Tip:_** Can be a comma separated list of e-mail addresses|
+|**mail.to**| To Address|No|**_Tip:_** Can be a list of e-mail addresses|
+|**mail.cc**| CC Address|No|**_Tip:_** Can be a list of e-mail addresses| 
+|**mail.bcc**| BCC Address|No |**_Tip:_** Can be a list of e-mail addresses|
 |**mail.from**|From address|No||
-|**mail.header**|Additional Headers|No|**_Tip:_** Use `Reply-To=<e-mail address>` to set a reply to address|
+|**mail.headers**|Additional Headers|No|**_Tip:_** Use `Reply-To=<e-mail address>` to set a reply to address|
 |**mail.subject**| subject line|yes||
 |**mail.body**| Message Body|No|Per Ansible module, defaults to the mail subject|
 |**mail.secure**|Security Value|No||
@@ -42,8 +42,11 @@ mail:
   secure: "always"
   username: "user1@example.com"
   password: "pa55word"
-  header: 'Reply-To=user2@example.com'
-  to: "person1@example.com, person2@example.com"
+  headers:
+  - 'Reply-To=user2@example.com'
+  to:
+  - "person1@example.com"
+  - "person2@example.com"
   subject: "Test Message 1"
   body: "<html><body><h1>This is a H1 header</h1></body></html>"
   subtype: "html"
@@ -55,17 +58,17 @@ Example inventory to combine a *fixed* list of users + a passed in list of users
 
 ```
 list_of_mail_to:
-  - to_user1@example.com
-  - to_user2@example.com
-  - to_user3@example.com
+- to_user1@example.com
+- to_user2@example.com
+- to_user3@example.com
 
 list_of_mail_cc:
-  - cc_user1@example.com 
-  - cc_user2@example.com
+- cc_user1@example.com 
+- cc_user2@example.com
 
 list_of_mail_bcc:
-  - bcc_user1@example.com
-  - bcc_user2@example.com
+- bcc_user1@example.com
+- bcc_user2@example.com
 
 
 mail:
@@ -74,8 +77,11 @@ mail:
   secure: "always"
   username: "user1@example.com"
   password: "pa55word"
-  header: 'Reply-To=user2@example.com'
-  to: "person1@example.com, person2@example.com"
+  headers: 
+  - 'Reply-To=user2@example.com'
+  to:
+  - "person1@example.com"
+  - "person2@example.com"
   subject: "Subject of the message"
   body: "Body of the Notification Message"
 

--- a/roles/notifications/send-email/tasks/main.yml
+++ b/roles/notifications/send-email/tasks/main.yml
@@ -2,24 +2,21 @@
 
 - name: "Create the 'To:' list of addresses"
   set_fact:
-    mail:
-      to: "{{ list_of_mail_to | join(', ') }}, {{ mail.to | default('') }}"
+    mail: "{{ mail | combine({ 'to': list_of_mail_to }) }}"
   when:
-    - list_of_mail_to is defined
+  - list_of_mail_to is defined
 
 - name: "Create the 'CC:' list of addresses"
   set_fact:
-    mail:
-      cc: "{{ list_of_mail_cc | join(', ') }}, {{ mail.cc | default('') }}"
+    mail: "{{ mail | combine({ 'cc': list_of_mail_cc }) }}"
   when:
-    - list_of_mail_cc is defined
+  - list_of_mail_cc is defined
 
 - name: "Create the 'BCC:' list of addresses"
   set_fact:
-    mail:
-      bcc: "{{ list_of_mail_bcc | join(', ') }}, {{ mail.bcc | default('') }}"
+    mail: "{{ mail | combine({ 'bcc': list_of_mail_bcc }) }}"
   when:
-    - list_of_mail_bcc is defined
+  - list_of_mail_bcc is defined
 
 - name: "Send out e-mail content to users"
   mail:
@@ -33,6 +30,6 @@
     cc: "{{ mail.cc | default(omit) }}"
     bcc: "{{ mail.bcc | default(omit) }}"
     from: "{{ mail.from | default(omit)}}"
-    headers: "{{ mail.header | default(omit)}}"
+    headers: "{{ mail.headers | default(omit)}}"
     secure: "{{ mail.secure | default(omit) }}"
     subtype: "{{ mail.subtype | default(omit) }}"

--- a/roles/notifications/send-email/tests/inventory/group_vars/all.yml
+++ b/roles/notifications/send-email/tests/inventory/group_vars/all.yml
@@ -6,8 +6,11 @@ mail:
   username: "user1@example.com"
   password: "pa55word"
   secure: "always"
-  header: 'Reply-To=user2@example.com'
-  to: "person1@example.com, person2@example.com"
+  headers:
+  - 'Reply-To=user2@example.com'
+  to:
+  - "person1@example.com"
+  - "person2@example.com"
   subject: "Test Message 1"
   body: "<html><body><h1>This is a H1 header</h1></body></html>"
   subtype: "html"

--- a/roles/notifications/send-email/tests/test.yml
+++ b/roles/notifications/send-email/tests/test.yml
@@ -3,6 +3,5 @@
 
 - name: Test email/send role
   hosts: localhost
-
   roles:
-    - email/send
+  - notifications/send-email


### PR DESCRIPTION
### What does this PR do?
The `mail` module changed (for the better) in Ansible 2.5 to accept a true list (instead of comma separated lists). This PR changes the role (and corresponding playbooks) to adopt the 2.5 approach. + a few other issues have been fixed as well.

### How should this be tested?
See `tests` part of the `send-email` role. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
