### PR TITLE
Update notifications subject to use title

### DIFF
--- a/playbooks/notifications/email-notify-list-of-users.yml
+++ b/playbooks/notifications/email-notify-list-of-users.yml
@@ -11,7 +11,7 @@
     vars:
       markdown_content: "{{ body }}"
   - set_fact:
-      mail: "{{ mail | combine({ 'subject': subject, 'body': md_to_html.html_body_message }) }}"
+      mail: "{{ mail | combine({ 'subject': title, 'body': md_to_html.html_body_message }) }}"
   - set_fact:
       list_of_mail_to: "{{ list_of_mail_to | default([]) }} + [ '{{ item.email }}' ]"
     with_items:


### PR DESCRIPTION
### What does this PR do?
This PR changes the `email-notify-list-of-users.yml` to set the subject of an email to use `title` instead of looking for a var called `subject`. This brings this playbook into line with the other notifications playbooks and allows the playbook to complete as expected.

Currently this isn't working because the playbook is searching for a variable called subject. Based on docs and the other notifications playbooks, we intend to use the `title` variable, which is causing this to break at this point.

### How should this be tested?

Send an email to a list of users:

- Using the current playbook (not the one introduced in this PR) and setting the title of an email with title, you will see the message `"msg": "|combine expects dictionaries,`. This is because this playbook expects the title of an email to be set with subject. Because it's not, this causes an issue when building the dict that the mail module expects.
- Using the playbook introduced in this PR and setting the title of an email with title, you will see the email sent successfully

### People to notify
cc: @redhat-cop/infra-ansible
