### PR TITLE
Add LDAP login to Tower

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
+++ b/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
@@ -35,4 +35,17 @@
     notify:
     - restart-tower
 
+  - name: "Force LDAP Sync"
+    uri:
+      url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/"
+      user: "{{ ansible_tower.ldap.bind_dn.split(',') | first | regex_replace('uid=') }}"
+      password: "{{ ansible_tower.ldap.bind_password }}"
+      force_basic_auth: yes
+      method: GET
+      validate_certs: no
+    register: status_output
+    until: status_output.status == 200
+    retries: 6
+    delay: 5
+
   become: True


### PR DESCRIPTION
### What does this PR do?
This PR adds a task to the `config-ansible-tower-ldap` role that simulates a login to tower with the provided LDAP bind user credentials. This forces an ldap sync that will then allow the successful import of the other components that may be specified (teams, orgs, etc.). This is useful in scenarios where you're trying to load in projects or inventories that rely on this components to already be loaded/exist.

### How should this be tested?
This can be tested by specifying an inventory that provides an organization_map and a team_map. 
```
ansible_tower:
  ldap:
    ca_cert: "{{ inventory_dir }}/../files/certs/my-cert.crt"
    uri: "ldaps://my-ldap.example.com:636"
    bind_dn: "uid=my-bind-user,cn=users,cn=accounts,dc=example,dc=com"
    bind_password: "my-bind-password"
    user_search_dn: "cn=users,cn=accounts,dc=example,dc=com"
    user_dn_template: "uid=%(user)s,cn=users,cn=accounts,dc=example,dc=com"
    group_search_dn: "cn=groups,cn=accounts,dc=example,dc=com"
    require_group: "cn=my-user-group,cn=groups,cn=accounts,dc=example,dc=com"
    admin_group: "cn=my-admin-group,cn=groups,cn=accounts,dc=example,dc=com"
    organization_map:
    - name: "Demo Org"
      admin_group: "cn=my-admin-group,cn=groups,cn=accounts,dc=example,dc=com"
      user_groups:
      - "cn=my-user-group,cn=groups,cn=accounts,dc=example,dc=com"
    team_map:
    - name: "Demo Team"
      organization: "Demo Org"
      user_groups:
      - "cn=my-user-group,cn=groups,cn=accounts,dc=example,dc=com"
```

Without this PR, you'll notice that your orgs and teams aren't loaded into Tower until after the first succesful login from an LDAP user. After this PR is applied, you'll see that the login is done as part of the configuration and your orgs/teams will appear immediately.

### People to notify
cc: @redhat-cop/infra-ansible
