### PR TITLE
Update deprecated filter

### DIFF
--- a/roles/ansible/prep-for-ansible/tasks/main.yml
+++ b/roles/ansible/prep-for-ansible/tasks/main.yml
@@ -9,6 +9,6 @@
 - name: "Install python2 and dnf stuff to allow for Ansible operation"
   raw: dnf -y install python-dnf libselinux-python
   when:
-  - facts|failed
+  - facts is failed
 
 


### PR DESCRIPTION
### What does this PR do?
This PR changes the filter from `facts|failed` to `facts is failed`. This will remove the deprecation warning that we see when using this role.

### How should this be tested?
Create a playbook that uses this role. Before this PR, you would receive a deprecation warning that notifies you that this will stop working in a future version of Ansible. After this PR, you will see the playbook execute with no warning.

Example:
```
- hosts: testing
  tasks:
    - import_role:
        name: ansible/prep-for-ansible
```

### People to notify
cc: @redhat-cop/infra-ansible
