### PR TITLE
Update Tower LDAP Login

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
+++ b/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
@@ -37,7 +37,7 @@
 
   - name: "Force LDAP Sync"
     uri:
-      url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/"
+      url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/"
       user: "{{ ansible_tower.ldap.bind_dn.split(',') | first | regex_replace('uid=') }}"
       password: "{{ ansible_tower.ldap.bind_password }}"
       force_basic_auth: yes


### PR DESCRIPTION
### What does this PR do?
Currently a workaround is required in order to have the LDAP tower configs sync. It appears that just authenticating isn't enough to cause the sync to occur. This PR changes the call to grab the api version (could have been any action) in order for the configs to by synced

### How should this be tested?
Specify an inventory that installs tower and specifies an ldap config. Then run `ansible-playbook -i inventory playbooks/provision-ansible-tower/main.yml --tags='install,all'`. Afterwards, login and verify that your ldap configs are in place (organizations and teams appear).

### People to notify
cc: @redhat-cop/infra-ansible
