### PR TITLE
Haproxy

### DIFF
--- a/roles/load-balancers/manage-haproxy/README.md
+++ b/roles/load-balancers/manage-haproxy/README.md
@@ -103,6 +103,24 @@ defaults
 
 ```
 
+## stats.cfg file
+
+```
+frontend lb_stats_fe
+    bind 192.168.1.10:8080
+
+    default_backend lb_stats_be
+
+
+backend lb_stats_be
+    mode http
+    stats enable
+    stats uri /stats
+    stats realm Haproxy\ Statistics
+    stats auth admin:admin
+
+```
+
 ### frontend.cfg file
 
 ```

--- a/roles/load-balancers/manage-haproxy/README.md
+++ b/roles/load-balancers/manage-haproxy/README.md
@@ -3,8 +3,8 @@
 This role has 3 features:
 
  1) installs HAproxy and configures the host to run it ( *install.yml* )
- 2) generates a `haproxy.cfg` file ( *generate-config.yml* )
- 3) activates the haproxy.cfg file on the host ( *activate-config.yml* )
+ 2) generates multiple configuration files ( *generate-config.yml* )
+ 3) activates the configuration files on the host ( *activate-config.yml* )
 
 ## Example
 
@@ -56,7 +56,7 @@ lb_config:
 ```
 
 
-### haproxy.cfg file
+### global.cfg file
 
 ```
 #---------------------------------------------------------------------
@@ -101,8 +101,11 @@ defaults
     timeout check           10s
     maxconn                 3000
 
+```
 
+### frontend.cfg file
 
+```
 frontend my-secure-web-server-8443
     bind 192.168.1.10:8443
     mode tcp
@@ -127,19 +130,6 @@ frontend my-secure-web-server
 
     use_backend https_443-router.env1.example.com if router.env1.example.com
 
-backend https_443-router.env1.example.com
-    mode tcp
-    balance roundrobin
-
-    server router1.env1.example.com router1.env1.example.com:443 check
-    server router2.env1.example.com router2.env1.example.com:443 check
-
-
-backend https_8443-master1.env1.example.com
-    mode tcp
-    balance roundrobin
-
-    server master1.env1.example.com master1.env1.example.com:8443 check
 
 frontend my-web-server
     bind 192.168.1.10:80
@@ -149,7 +139,27 @@ frontend my-web-server
     use_backend http_80-router.env1.example.com if router.env1.example.com
 
     default_backend lb_http_default
+```
 
+### backend files
+```
+backend https_443-router.env1.example.com
+    mode tcp
+    balance roundrobin
+
+    server router1.env1.example.com router1.env1.example.com:443 check
+    server router2.env1.example.com router2.env1.example.com:443 check
+```
+
+```
+backend https_8443-master1.env1.example.com
+    mode tcp
+    balance roundrobin
+
+    server master1.env1.example.com master1.env1.example.com:8443 check
+```
+
+```
 backend http_80-router.env1.example.com
     balance roundrobin
     option httpclose
@@ -158,7 +168,9 @@ backend http_80-router.env1.example.com
 
     server router1.env1.example.com router1.env1.example.com:80 cookie A check
     server router2.env1.example.com router2.env1.example.com:80 cookie A check
+```
 
+```
 backend lb_http_default
     mode http
     stats enable

--- a/roles/load-balancers/manage-haproxy/defaults/main.yml
+++ b/roles/load-balancers/manage-haproxy/defaults/main.yml
@@ -2,7 +2,7 @@
 
 conf_dir: '/etc/haproxy/conf.d/'
 
-temp_new_dir: '/etc/haproxy/conf.d.new'
+temp_new_dir: '/etc/haproxy/conf.d.new/'
 
 service_file: '/usr/lib/systemd/system/haproxy.service'
 

--- a/roles/load-balancers/manage-haproxy/defaults/main.yml
+++ b/roles/load-balancers/manage-haproxy/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 
 conf_dir: '/etc/haproxy/conf.d/'
+
 temp_new_dir: '/etc/haproxy/conf.d.new'
+
+service_file: '/usr/lib/systemd/system/haproxy.service'
+
 lb_https_backends: {}

--- a/roles/load-balancers/manage-haproxy/defaults/main.yml
+++ b/roles/load-balancers/manage-haproxy/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 
-temp_new_file: '/etc/haproxy/haproxy.cfg.new'
+conf_dir: '/etc/haproxy/conf.d/'
+temp_new_dir: '/etc/haproxy/conf.d.new'
 lb_https_backends: {}

--- a/roles/load-balancers/manage-haproxy/handlers/main.yml
+++ b/roles/load-balancers/manage-haproxy/handlers/main.yml
@@ -21,9 +21,9 @@
     state: reloaded
   become: True
 
-- name: 'remove tmp new file'
+- name: 'remove tmp new directory'
   file:
-    path: '{{ temp_new_file }}'
+    path: '{{ temp_new_dir }}'
     state: absent
   become: True
 

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -3,41 +3,40 @@
 # Use a 'block' to ensure "become: True" for all tasks requiring elevated privileges
 - block:
 
-  - name: 'Copy the HAproxy config files to a temp location for validity checking'
-    copy:
-      src: "{{ haproxy_temp_dir }}"
-      dest: /etc/haproxy/
-    #notify: 'rename configuration dir'
-
-  - name: 'Ensure conf.d directory exists'
+  - name: 'Create remote diriectory for validity checking'
     file:
-      path: /etc/haproxy/conf.d
+      path: "{{ temp_new_dir }}"
       state: directory
 
-  #
-  # - name: 'Copy the HAproxy config file to a temp location for validity checking'
-  #   copy:
-  #     src: '{{ haproxy_temp_file }}'
-  #     dest: '{{ temp_new_file }}'
+  - name: 'Copy the HAproxy config files to a temp location for validity checking'
+    copy:
+      src: "{{ item }}"
+      dest: "{{ temp_new_dir }}"
+    with_fileglob:
+      - "{{ haproxy_temp_dir }}/*"
+    notify: 'cleanup temp dir'
 
-  # - name: 'Check the validity'
-  #   command: 'haproxy -c -f {{ temp_new_file }}'
-  #   notify: 'remove tmp new file'
+  - name: 'Get a list of config files'
+    find:
+      paths: "{{ temp_new_dir }}"
+    register: config_files
 
-  # - name: 'Copy and activate the HAproxy config file'
-  #   copy:
-  #     src: '{{ haproxy_temp_file }}'
-  #     dest: '/etc/haproxy/haproxy.cfg'
-  #     backup: 'yes'
-  #   notify: 'reload haproxy'
+  - name: 'Build validity command'
+    set_fact:
+      validity_list: "{{ validity_list | default('')  + ' -f ' + item.path }}"
+    with_items: "{{ config_files.files }}"
 
-  # - name: Ansible check file exists example.
-  #   stat:
-  #     path: "{{ haproxy_temp_dir }}"
-  #   register: file_details
-  #
-  # - debug:
-  #     msg: "{{ file_details }}"
+  - name: 'Check the validity'
+    command: 'haproxy -c {{ validity_list }}'
+    notify: 'remove tmp new directory'
+
+  - name: 'Copy and activate the HAproxy config files'
+    synchronize:
+      src: '{{ temp_new_dir }}/'
+      dest: '{{ conf_dir }}'
+      delete: true
+    delegate_to: "{{ inventory_hostname }}"
+    #notify: 'reload haproxy'
 
   - name: 'Open Firewall for LB use (TCP only)'
     firewalld:
@@ -61,12 +60,3 @@
 
   # End of outer block for "become: True"
   become: True
-
-- name: 'Clean-up the temp file'
-  file:
-    path: "{{ haproxy_temp_file }}"
-    state: absent
-  when:
-  - (clean_up_temp|default('yes'))|lower == 'yes'
-  delegate_to: localhost
-  run_once: True

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -3,21 +3,41 @@
 # Use a 'block' to ensure "become: True" for all tasks requiring elevated privileges
 - block:
 
-  - name: 'Copy the HAproxy config file to a temp location for validity checking'
+  - name: 'Copy the HAproxy config files to a temp location for validity checking'
     copy:
-      src: '{{ haproxy_temp_file }}'
-      dest: '{{ temp_new_file }}'
+      src: "{{ haproxy_temp_dir }}"
+      dest: /etc/haproxy/
+    #notify: 'rename configuration dir'
 
-  - name: 'Check the validity'
-    command: 'haproxy -c -f {{ temp_new_file }}'
-    notify: 'remove tmp new file'
+  - name: 'Ensure conf.d directory exists'
+    file:
+      path: /etc/haproxy/conf.d
+      state: directory
 
-  - name: 'Copy and activate the HAproxy config file'
-    copy:
-      src: '{{ haproxy_temp_file }}'
-      dest: '/etc/haproxy/haproxy.cfg'
-      backup: 'yes'
-    notify: 'reload haproxy'
+  #
+  # - name: 'Copy the HAproxy config file to a temp location for validity checking'
+  #   copy:
+  #     src: '{{ haproxy_temp_file }}'
+  #     dest: '{{ temp_new_file }}'
+
+  # - name: 'Check the validity'
+  #   command: 'haproxy -c -f {{ temp_new_file }}'
+  #   notify: 'remove tmp new file'
+
+  # - name: 'Copy and activate the HAproxy config file'
+  #   copy:
+  #     src: '{{ haproxy_temp_file }}'
+  #     dest: '/etc/haproxy/haproxy.cfg'
+  #     backup: 'yes'
+  #   notify: 'reload haproxy'
+
+  # - name: Ansible check file exists example.
+  #   stat:
+  #     path: "{{ haproxy_temp_dir }}"
+  #   register: file_details
+  #
+  # - debug:
+  #     msg: "{{ file_details }}"
 
   - name: 'Open Firewall for LB use (TCP only)'
     firewalld:

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -16,9 +16,9 @@
       - "{{ haproxy_temp_dir }}/*"
     notify: 'cleanup temp dir'
 
-  - name: 'Add LB Global file valid file options'
+  - name: 'Add LB haproxy file valid file options'
     set_fact:
-        valid_file_opts: "{{ valid_file_opts | default('') + ' -f {{ temp_new_dir }}global.cfg' }}"
+        valid_file_opts: "{{ valid_file_opts | default('') + ' -f {{ temp_new_dir }}haproxy.cfg' }}"
 
   - name: 'Add LB Frontends file valid file options'
     set_fact:

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -53,9 +53,6 @@
     set_fact:
       config_file_opts: "{{ valid_file_opts | regex_replace(temp_new_dir, conf_dir)}}"
 
-  - debug:
-      msg: "{{ config_file_opts }}"
-
   - name: 'Edit the HAproxy service file and activate service'
     template:
       src: "{{ service_template | default('haproxy.service.j2') }}"

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -16,18 +16,19 @@
       - "{{ haproxy_temp_dir }}/*"
     notify: 'cleanup temp dir'
 
-  - name: 'Get a list of config files'
-    find:
-      paths: "{{ temp_new_dir }}"
-    register: config_files
-
-  - name: 'Build validity command'
+  - name: 'Initilize config_file_opts with LB Global and LB Frontend files'
     set_fact:
-      validity_list: "{{ validity_list | default('')  + ' -f ' + item.path }}"
-    with_items: "{{ config_files.files }}"
+        config_file_opts: '-f {{ conf_dir }}global.cfg -f {{ conf_dir }}frontends.cfg'
+
+  - name: 'Add LB Backends to config_file_opts'
+    set_fact:
+        config_file_opts: "{{ config_file_opts + ' -f ' + conf_dir + 'backend-' + backend_entry.lb_match_fqdn + '.cfg' }}"
+    loop_control:
+      loop_var: backend_entry
+    loop: "{{ lb_config.lb_entries }}"
 
   - name: 'Check the validity'
-    command: 'haproxy -c {{ validity_list }}'
+    command: 'haproxy -c {{ config_file_opts }}'
     notify: 'remove tmp new directory'
 
   - name: 'Copy and activate the HAproxy config files'
@@ -36,7 +37,12 @@
       dest: '{{ conf_dir }}'
       delete: true
     delegate_to: "{{ inventory_hostname }}"
-    #notify: 'reload haproxy'
+
+  - name: 'Edit the HAproxy service file'
+    template:
+      src: "{{ service_template | default('haproxy.service.j2') }}"
+      dest:  "{{ service_file }}"
+    notify: 'reload haproxy'
 
   - name: 'Open Firewall for LB use (TCP only)'
     firewalld:

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -16,16 +16,27 @@
       - "{{ haproxy_temp_dir }}/*"
     notify: 'cleanup temp dir'
 
-  - name: 'Initilize valid_file_opts with LB Global and LB Frontend files'
+  - name: 'Add LB Global file valid file options'
     set_fact:
-        valid_file_opts: '-f {{ temp_new_dir }}global.cfg -f {{ temp_new_dir }}frontends.cfg'
+        valid_file_opts: "{{ valid_file_opts | default('') + ' -f {{ temp_new_dir }}global.cfg' }}"
 
-  - name: 'Add LB Backends to config_file_opts'
+  - name: 'Add LB Frontends file valid file options'
+    set_fact:
+        valid_file_opts: "{{ valid_file_opts | default('') + ' -f {{ temp_new_dir }}frontends.cfg' }}"
+    when: lb_config.frontends is defined
+
+  - name: 'Add LB Stats file valid file options'
+    set_fact:
+        valid_file_opts: "{{ valid_file_opts | default('') + ' -f {{ temp_new_dir }}stats.cfg' }}"
+    when: lb_config.stats_page is defined
+
+  - name: 'Add LB Backends to valid file options'
     set_fact:
         valid_file_opts: "{{ valid_file_opts + ' -f ' + temp_new_dir + 'backend-' + backend_entry.lb_match_fqdn + '.cfg' }}"
     loop_control:
       loop_var: backend_entry
     loop: "{{ lb_config.lb_entries }}"
+    when: lb_config.lb_entries is defined
 
   - name: 'Check the validity'
     command: 'haproxy -c {{ valid_file_opts }}'
@@ -38,16 +49,12 @@
       delete: true
     delegate_to: "{{ inventory_hostname }}"
 
-  - name: 'Initilize config_file_opts with LB Global and LB Frontend files'
+  - name: 'Convert valid file options into configuration file options'
     set_fact:
-        config_file_opts: '-f {{ conf_dir }}global.cfg -f {{ conf_dir }}frontends.cfg'
+      config_file_opts: "{{ valid_file_opts | regex_replace(temp_new_dir, conf_dir)}}"
 
-  - name: 'Add LB Backends to config_file_opts'
-    set_fact:
-        config_file_opts: "{{ config_file_opts + ' -f ' + conf_dir + 'backend-' + backend_entry.lb_match_fqdn + '.cfg' }}"
-    loop_control:
-      loop_var: backend_entry
-    loop: "{{ lb_config.lb_entries }}"
+  - debug:
+      msg: "{{ config_file_opts }}"
 
   - name: 'Edit the HAproxy service file and activate service'
     template:

--- a/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/activate-config.yml
@@ -16,6 +16,28 @@
       - "{{ haproxy_temp_dir }}/*"
     notify: 'cleanup temp dir'
 
+  - name: 'Initilize valid_file_opts with LB Global and LB Frontend files'
+    set_fact:
+        valid_file_opts: '-f {{ temp_new_dir }}global.cfg -f {{ temp_new_dir }}frontends.cfg'
+
+  - name: 'Add LB Backends to config_file_opts'
+    set_fact:
+        valid_file_opts: "{{ valid_file_opts + ' -f ' + temp_new_dir + 'backend-' + backend_entry.lb_match_fqdn + '.cfg' }}"
+    loop_control:
+      loop_var: backend_entry
+    loop: "{{ lb_config.lb_entries }}"
+
+  - name: 'Check the validity'
+    command: 'haproxy -c {{ valid_file_opts }}'
+    notify: 'remove tmp new directory'
+
+  - name: 'Copy the HAproxy config files'
+    synchronize:
+      src: '{{ temp_new_dir }}/'
+      dest: '{{ conf_dir }}'
+      delete: true
+    delegate_to: "{{ inventory_hostname }}"
+
   - name: 'Initilize config_file_opts with LB Global and LB Frontend files'
     set_fact:
         config_file_opts: '-f {{ conf_dir }}global.cfg -f {{ conf_dir }}frontends.cfg'
@@ -27,18 +49,7 @@
       loop_var: backend_entry
     loop: "{{ lb_config.lb_entries }}"
 
-  - name: 'Check the validity'
-    command: 'haproxy -c {{ config_file_opts }}'
-    notify: 'remove tmp new directory'
-
-  - name: 'Copy and activate the HAproxy config files'
-    synchronize:
-      src: '{{ temp_new_dir }}/'
-      dest: '{{ conf_dir }}'
-      delete: true
-    delegate_to: "{{ inventory_hostname }}"
-
-  - name: 'Edit the HAproxy service file'
+  - name: 'Edit the HAproxy service file and activate service'
     template:
       src: "{{ service_template | default('haproxy.service.j2') }}"
       dest:  "{{ service_file }}"

--- a/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
@@ -3,20 +3,9 @@
 # Use a 'block' to ensure it all runs on 'localhost'
 - block:
 
-  - name: 'Create a temporary HAproxy config file'
-    tempfile:
-      state: file
-      suffix: haproxy
-    register: tempfile
-
-  - name: 'Store away the HAproxy temp config file name'
-    set_fact:
-      haproxy_temp_file: "{{ tempfile.path }}"
-
   - name: 'Use a unique temporary directory to store the config files pre-assemble'
     command: mktemp -d
     register: tempdir
-  #  notify: 'cleanup temp dir'
 
   - name: 'Store away the temp names'
     set_fact:
@@ -25,23 +14,20 @@
   - name: 'Populate the common config portion for HAproxy'
     template:
       src: "{{ lb_common_template | default('lb_common.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/0001_lb.cfg'
+      dest: '{{ haproxy_temp_dir }}/global.cfg'
 
   - name: 'Configure and Populate LB Frontends'
     template:
       src: "{{ lb_frontend_template | default('lb_frontend.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/0002_lb_{{ fe.lb_name }}_{{ fe.lb_host_vip }}_{{ fe.lb_host_port }}.cfg'
+      dest: '{{ haproxy_temp_dir }}/fe.cfg'
     loop_control:
       loop_var: fe
     loop: "{{ lb_config.frontends|flatten(levels=1) }}"
 
-  - debug:
-      msg: "{{ haproxy_temp_dir }}"
-
   - name: 'Configure and Populate LB Backends'
     template:
       src: "{{ lb_backend_template | default('lb_backend.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/{{ backend_entry.lb_match_fqdn }}.cfg'
+      dest: '{{ haproxy_temp_dir }}/be-{{ backend_entry.lb_match_fqdn }}.cfg'
     loop_control:
       loop_var: backend_entry
     loop: "{{ lb_config.lb_entries }}"
@@ -51,16 +37,11 @@
       page_config: "{{ lb_config.stats_page }}"
     template:
       src: lb_http_stats.j2
-      dest: '{{ haproxy_temp_dir }}/0004_lb.cfg'
+      dest: '{{ haproxy_temp_dir }}/stats.cfg'
     when:
     - lb_config.stats_page is defined
     - lb_config.stats_page.enabled is defined
     - lb_config.stats_page.enabled
-
-  - name: 'Assemble the final HAproxy config file'
-    assemble:
-      src: '{{ haproxy_temp_dir }}'
-      dest: '{{ haproxy_temp_file }}'
 
   # Delegate the entire block to "localhost"
   delegate_to: localhost

--- a/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
@@ -16,7 +16,7 @@
   - name: 'Use a unique temporary directory to store the config files pre-assemble'
     command: mktemp -d
     register: tempdir
-    notify: 'cleanup temp dir'
+  #  notify: 'cleanup temp dir'
 
   - name: 'Store away the temp names'
     set_fact:
@@ -35,10 +35,16 @@
       loop_var: fe
     loop: "{{ lb_config.frontends|flatten(levels=1) }}"
 
+  - debug:
+      msg: "{{ haproxy_temp_dir }}"
+
   - name: 'Configure and Populate LB Backends'
     template:
       src: "{{ lb_backend_template | default('lb_backend.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/0003_lb.cfg'
+      dest: '{{ haproxy_temp_dir }}/{{ backend_entry.lb_match_fqdn }}.cfg'
+    loop_control:
+      loop_var: backend_entry
+    loop: "{{ lb_config.lb_entries }}"
 
   - name: 'Populate the stats page config'
     vars:

--- a/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
@@ -19,15 +19,12 @@
   - name: 'Configure and Populate LB Frontends'
     template:
       src: "{{ lb_frontend_template | default('lb_frontend.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/fe.cfg'
-    loop_control:
-      loop_var: fe
-    loop: "{{ lb_config.frontends|flatten(levels=1) }}"
+      dest: '{{ haproxy_temp_dir }}/frontends.cfg'
 
   - name: 'Configure and Populate LB Backends'
     template:
       src: "{{ lb_backend_template | default('lb_backend.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/be-{{ backend_entry.lb_match_fqdn }}.cfg'
+      dest: '{{ haproxy_temp_dir }}/backend-{{ backend_entry.lb_match_fqdn }}.cfg'
     loop_control:
       loop_var: backend_entry
     loop: "{{ lb_config.lb_entries }}"

--- a/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
@@ -14,7 +14,7 @@
   - name: 'Populate the common config portion for HAproxy'
     template:
       src: "{{ lb_common_template | default('lb_common.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/global.cfg'
+      dest: '{{ haproxy_temp_dir }}/haproxy.cfg'
 
   - name: 'Configure and Populate LB Frontends'
     template:

--- a/roles/load-balancers/manage-haproxy/templates/haproxy.service.j2
+++ b/roles/load-balancers/manage-haproxy/templates/haproxy.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=HAProxy Load Balancer
+After=syslog.target network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/haproxy
+ExecStart=/usr/sbin/haproxy-systemd-wrapper {{ config_file_opts }} -p /run/haproxy.pid $OPTIONS
+ExecReload=/bin/kill -USR2 $MAINPID
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/load-balancers/manage-haproxy/templates/lb_backend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_backend.j2
@@ -1,16 +1,14 @@
 
-{% for entry in lb_config.lb_entries %}
-
-{% if ((entry.lb_ssl_enabled is defined and entry.lb_ssl_enabled) or
-       (entry.lb_ssl_enabled is undefined and entry.lb_match_port|string == '443')) %}
+{% if ((backend_entry.lb_ssl_enabled is defined and backend_entry.lb_ssl_enabled) or
+       (backend_entry.lb_ssl_enabled is undefined and backend_entry.lb_match_port|string == '443')) %}
 {% set lb_ssl_enabled = True %}
 {% else %}
 {% set lb_ssl_enabled = False %}
 {% endif %}
 
-{% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
+{% set lb_match_fqdn = (backend_entry.name | default(backend_entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
 
-backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }}
+backend {{ lb_match_fqdn }}-{{ backend_entry.lb_match_port }}
     balance roundrobin
 {% if lb_ssl_enabled %}
     mode tcp
@@ -20,15 +18,13 @@ backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }}
     cookie JSESSIONID prefix
 {% endif %}
 
-{% for backend in entry.backends %}
+{% for backend in backend_entry.backends %}
 {% set lb_backend_host = backend.name | default(backend.host) %}
-{% set lb_backend_port = backend.port | default(entry.lb_match_port) %}
+{% set lb_backend_port = backend.port | default(backend_entry.lb_match_port) %}
 
 {% if lb_ssl_enabled %}
     server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} check
 {% else %}
     server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} cookie A check
 {% endif %}
-{% endfor %}
-
 {% endfor %}

--- a/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
@@ -1,3 +1,4 @@
+{% for fe in lb_config.frontends|flatten(levels=1) %}
 
 {% if ((fe.lb_ssl_enabled is defined and fe.lb_ssl_enabled) or
        (fe.lb_ssl_enabled is undefined and fe.lb_host_port|string == '443')) %}
@@ -36,3 +37,5 @@ frontend {{ fe.lb_name }}
 {% else %}
     default_backend {{ fe.lb_name }}
 {% endif %}
+
+{% endfor %}


### PR DESCRIPTION
### What does this PR do?
Updates the manage-haproxy role to split the configuration across multiple files.

### How should this be tested?
This can be tested using an inventory much like the one in the README. By default the configuration files are placed in /etc/haproxy/conf.d. 

### Is there a relevant Issue open for this?
resolves #279

### People to notify
cc: @redhat-cop/infra-ansible
