### PR TITLE
change to use notification, password does not work anymore

### DIFF
--- a/roles/user-management/manage-atlassian-users/tasks/create_atlassian_users.yml
+++ b/roles/user-management/manage-atlassian-users/tasks/create_atlassian_users.yml
@@ -8,10 +8,11 @@
     force_basic_auth: yes
     status_code: 201
     body_format: json
-    body: "{'name': '{{ atlassian_user.email.split(\"@\") | first }}', 
-            'password': '{{ atlassian_user.password }}', 
-            'emailAddress': '{{ atlassian_user.email }}', 
-            'displayName': '{{ atlassian_user.firstname }} {{ atlassian_user.lastname }}' }"
+    body:
+      name: "{ atlassian_user.email.split(\"@\") | first }}"
+      emailAddress: "{{ atlassian_user.email }}"
+      displayName: "{{ atlassian_user.firstname }} {{ atlassian_user.lastname }}"
+      notification: true
     return_content: yes
   register: user_data
   when: 


### PR DESCRIPTION
### What does this PR do?
change to use notification, password does not work anymore, update formatting

### How should this be tested?
```
$ ansible-playbook -e "@path/to/vars.yml" playbooks/manage-users/manage-atlassian-users.yml --ask-vault-pass
```
with vars like:
```
  vars:
    atlassian:
      url: https://atlassian.net
      username: your@username.com
      password: passwordORapiToken
      user:
        - firstname: Some
          lastname: patrick
          password: patrick
          email: patrick@example.com
          state: present
          groups:
            - patrick-test
      groups:
        - patrick-test
```
### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
