### PR TITLE
Updating config-pxe role to include BIO PXE files

### DIFF
--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -10,16 +10,16 @@
 - name: 'Configure DNS (internal)'
   hosts: dns_servers_internal
   roles:
-  - role: dns/config-dns-server
-  - role: dns/manage-dns-zones
+  - role: dns/config-dns-server-bind
+  - role: dns/manage-dns-zones-bind
   tags:
   - configure_dns_internal
 
 - name: 'Configure DNS (external)'
   hosts: dns_servers_external
   roles:
-  - role: dns/config-dns-server
-  - role: dns/manage-dns-zones
+  - role: dns/config-dns-server-bind
+  - role: dns/manage-dns-zones-bind
   tags:
   - configure_dns_external
 
@@ -33,7 +33,7 @@
 - name: 'Configure IdM'
   hosts: idm_servers
   roles:
-  - role: idm
+  - role: config-idm-server
   tags:
   - configure_idm
 

--- a/roles/config-pxe/tasks/pxe-target.yml
+++ b/roles/config-pxe/tasks/pxe-target.yml
@@ -11,6 +11,11 @@
   set_fact:
     pxe_entries: "{{ target_entry.pxe_entries }}"
 
+- name: "Populate the host specific pxelinux.cfg (BIOS) file"
+  template:
+    src: pxelinux_cfg.j2
+    dest: "{{ tftpserver_root_dir }}/pxelinux.cfg/01-{{ target_entry.mac|regex_replace(':', '-')|lower }}"
+
 - name: "Generate the mac-address specific grub.cfg"
   set_fact:
     target_file: "{{ tftpserver_root_dir }}/pxelinux/grub.cfg-01-{{ target_entry.mac|regex_replace(':', '-')|lower }}"

--- a/roles/config-pxe/tasks/pxe.yml
+++ b/roles/config-pxe/tasks/pxe.yml
@@ -52,7 +52,7 @@
     src: pxelinux_uefi.j2
     dest: "{{ tftpserver_root_dir }}/pxelinux/grub.cfg"
 
-- name: "Generate target specific UEFI grub.cfg file"
+- name: "Generate target specific files"
   include_tasks: pxe-target.yml
   loop_control:
     loop_var: target_entry

--- a/roles/config-pxe/templates/pxelinux_cfg.j2
+++ b/roles/config-pxe/templates/pxelinux_cfg.j2
@@ -16,7 +16,7 @@ LABEL local
 LABEL {{ entry.name }}
         MENU LABEL {{ entry.menu_label }}
         kernel {{ entry.kernel }}
-        append {{ entry.append }}
+        append {{ entry.append }} ip={{ ip_config | default('dhcp') }}
         ipappend 2
 
 {% endfor %}


### PR DESCRIPTION
### What does this PR do?
The 'config-pxe' role only supported generating uEFI **host specific** files, this role now also generate BIOS **host specific** files.

BTW: this PR also fixes an issue with the `services` playbook as some recent changes broke the execution of it. 

### How should this be tested?
Use the config-pxe role with a proper inventory to configure a setup to be used with PXE booting hosts in BIOS mode.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
