### PR TITLE
updates to notification playbooks

### DIFF
--- a/playbooks/notifications/email-notify-single-user.yml
+++ b/playbooks/notifications/email-notify-single-user.yml
@@ -1,7 +1,5 @@
 ---
 
-- include_vars:
-    file: "{{ email_content_file }}"
 - set_fact:
     markdown_content: "{{ body }}"
 - include_role:

--- a/playbooks/notifications/email-notify-users.yml
+++ b/playbooks/notifications/email-notify-users.yml
@@ -6,12 +6,12 @@
   tasks:
   - include_tasks: email-notify-single-user.yml
     vars:
-      first_name: "{{ item.first_name }}"
-      user_name: "{{ item.user_name }}"
-      password: "{{ item.password }}"
-      email_to: "{{ item.email }}"
+      first_name: "{{ user_to_notify.first_name }}"
+      user_name: "{{ user_to_notify.user_name }}"
+      email_to: "{{ user_to_notify.email }}"
     when:
-    - item.notify_user == True
+    - user_to_notify.notify_user == True
     with_items:
     - "{{ users }}"
-
+    loop_control:
+      loop_var: user_to_notify


### PR DESCRIPTION
### What does this PR do?
Changes to email-notify-users playbooks to get rid of warning messages when running. Also removed set_fact with the email_content_file variable as it doesn't seem to be used anywhere else.

### How should this be tested?
Run against any inventory that used this playbook before. Be sure to delete the email_content_file variable.

### Is there a relevant Issue open for this?
None

### Other Relevant info, PRs, etc.
None

### People to notify
cc: @redhat-cop/infra-ansible
