### PR TITLE
support python3, smaller fixes, work on Fedora for casl

### DIFF
--- a/roles/virt-install/defaults/main.yml
+++ b/roles/virt-install/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 
+# consider that this role isn't run against the created VMs but against the virtualization host,
+# i.e. you can only overwrite these variables in the inventory by defining them at the host level.
+# Use the libvirt_... variables to overwrite them at the VM level.
+
 default_http_dir: "/var/www/html"
 default_http_host: "192.168.122.1"
 

--- a/roles/virt-install/handlers/main.yml
+++ b/roles/virt-install/handlers/main.yml
@@ -2,10 +2,9 @@
 
 - name: 'Unmount install ISO'
   mount:
-    path: "{{ mounted_iso[item] }}"
+    path: "{{ item.value }}"
     state: absent
-  with_items:
-  - "{{ mounted_iso.keys() }}"
+  loop: "{{ mounted_iso | dict2items }}"
 
 - name: 'Remove authorized_keys'
   file: 

--- a/roles/virt-install/tasks/create_vm.yml
+++ b/roles/virt-install/tasks/create_vm.yml
@@ -8,6 +8,7 @@
 - name: 'Gather the list of existing VMs'
   command: virsh list --name
   register: existing_vms
+  check_mode: false
 
 - name: 'Compose Command for new VM provisioning'
   include_tasks: 'virt-install.yml'

--- a/roles/virt-install/tasks/prereq.yml
+++ b/roles/virt-install/tasks/prereq.yml
@@ -7,7 +7,7 @@
   with_items:
   - virt-install
   - httpd
-  - libselinux-python
+  - "{{ ((ansible_python_interpreter | default('somepython'))[-1] == '3') | ternary('python3-libselinux','libselinux-python') }}"
 
 - name: 'Enable and start libvirtd'
   service:

--- a/roles/virt-install/tasks/prereq.yml
+++ b/roles/virt-install/tasks/prereq.yml
@@ -15,10 +15,9 @@
     enabled: yes
     state: started
 
-- name: 'Enable and start httpd'
+- name: 'Start httpd (leave enabled as-is)'
   service:
     name: httpd
-    enabled: no
     state: started
 
 - name: 'Enable and start firewalld'

--- a/roles/virt-install/tasks/virt-install.yml
+++ b/roles/virt-install/tasks/virt-install.yml
@@ -76,4 +76,16 @@
 
 - name: "Set Fact for VM command"
   set_fact:
-    virt_install_commands: "{{ virt_install_commands | default([]) + [ ('virt-install' + ' --connect ' + virtinstall_connect + ' --virt-type ' + virtinstall_virt_type + ' --name ' + virtinstall_name + ' --metadata \"title=' + virtinstall_title + ',description=' + virtinstall_description + ',name=' + virtinstall_name + '\"' + virt_install_network_string + ' --memory ' + virtinstall_memory + ' --vcpus ' + virtinstall_vcpus + virt_install_disk_string + ' --os-variant ' + virtinstall_os_variant + ' --location http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename + ' --initrd-inject=/tmp/' + virtinstall_ksfile | basename + ' --extra-args \"inst.repo=http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename + ' inst.ks=file:/' + virtinstall_ksfile | basename + '\"' + ' --graphics spice ' + ' --video qxl ' + ' --channel spicevmc ' + ' --autostart ') ] }}"
+    virt_install_commands: >
+      {{ virt_install_commands | default([]) + [ ('virt-install'
+      + ' --connect ' + virtinstall_connect
+      + ' --virt-type ' + virtinstall_virt_type
+      + ' --name ' + virtinstall_name
+      + ' --metadata "title=' + virtinstall_title + ',description=' + virtinstall_description + ',name=' + virtinstall_name + '"'
+      + virt_install_network_string + virt_install_disk_string
+      + ' --os-variant ' + virtinstall_os_variant
+      + ' --memory ' + virtinstall_memory + ' --vcpus ' + virtinstall_vcpus
+      + ' --location http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename
+      + ' --initrd-inject=/tmp/' + virtinstall_ksfile | basename
+      + ' --extra-args "inst.repo=http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename + ' inst.ks=file:/' + virtinstall_ksfile | basename + '"'
+      + ' --graphics spice ' + ' --video qxl ' + ' --channel spicevmc ' + ' --autostart ') ] }}

--- a/roles/virt-install/tasks/virt-install.yml
+++ b/roles/virt-install/tasks/virt-install.yml
@@ -83,10 +83,15 @@
       + ' --virt-type ' + virtinstall_virt_type
       + ' --name ' + virtinstall_name
       + ' --metadata "title=' + virtinstall_title + ',description=' + virtinstall_description + ',name=' + virtinstall_name + '"'
-      + virt_install_network_string + virt_install_disk_string
+      + virt_install_network_string
+      + virt_install_disk_string
       + ' --os-variant ' + virtinstall_os_variant
-      + ' --memory ' + virtinstall_memory + ' --vcpus ' + virtinstall_vcpus
+      + ' --memory ' + virtinstall_memory
+      + ' --vcpus ' + virtinstall_vcpus
       + ' --location http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename
       + ' --initrd-inject=/tmp/' + virtinstall_ksfile | basename
       + ' --extra-args "inst.repo=http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename + ' inst.ks=file:/' + virtinstall_ksfile | basename + '"'
-      + ' --graphics spice ' + ' --video qxl ' + ' --channel spicevmc ' + ' --autostart ') ] }}
+      + ' --graphics spice '
+      + ' --video qxl '
+      + ' --channel spicevmc '
+      + ' --autostart ') ] }}

--- a/roles/virt-install/tasks/virt-install.yml
+++ b/roles/virt-install/tasks/virt-install.yml
@@ -64,6 +64,7 @@
     opts: loop
     fstype: iso9660
     state: mounted
+    boot: false # avoids that a dangling mount blocks boot process
   notify: 'Unmount install ISO'
   when:
   - mounted_iso[virtinstall_iso] is not defined


### PR DESCRIPTION
### What does this PR do?

basically small changes I needed to get casl running on my laptop:

- Select correct selinux python library depending on python version (hence the name of the branch)
- Add check_mode false to force listing VMs even in check mode (check mode still doesn't go through but at least further)
- Add a note that defaults variables must be overwritten in the host's inventory (and not on the VM's one)
- Make the ISO unmount handler work by replacing with_items with loops (might also be a Python 3 vs. 2 thingy, but the solution should work also for Python 2)
- Make virt-install command generation more readable by breaking it across multiple lines.

### How should this be tested?

Just check that there is no regression on RHEL 7 / Python 2 (no new feature)

### Is there a relevant Issue open for this?

n/a see GChat discussion on `#casl`

### Other Relevant info, PRs, etc.

n/a

### People to notify
cc: @redhat-cop/infra-ansible
