### PR TITLE
Add check_mode false to rhsm repo validation to avoid error during check

### DIFF
--- a/roles/rhsm/tasks/main.yml
+++ b/roles/rhsm/tasks/main.yml
@@ -45,6 +45,7 @@
   - name: "Obtain currently enabled repos"
     shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
     register: enabled_repos
+    check_mode: false  # aka run_always: true, makes sure next task doesn't unduly fail in check mode
 
   # Build the list of repos to disable/enable before calling 'subscription-manager' as it's a very 
   # expensive command to run and hence better to call just once (especially with a long list of repos)


### PR DESCRIPTION
### What does this PR do?
just adding check_mode: false to a command task that only gathers information so that the registered variable is defined also in check mode and can be used in follow-up tasks.

### How should this be tested?

Just test by using `ansible-playbook --check` on a playbook using the `rhsm` role and see that it works where it didn't work before.

### Is there a relevant Issue open for this?

Nope, but perhaps we should open a generic issue around adding `check_mode: false` to all commands just reading information.

### Other Relevant info, PRs, etc.
n/a

### People to notify
cc: @redhat-cop/infra-ansible
