### PR TITLE
Replace wait_for by wait_for_connection in update-host's wait-for-host.yml

### DIFF
--- a/roles/rhsm/tasks/main.yml
+++ b/roles/rhsm/tasks/main.yml
@@ -45,6 +45,7 @@
   - name: "Obtain currently enabled repos"
     shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
     register: enabled_repos
+    check_mode: false  # aka run_always: true, makes sure next task doesn't unduly fail in check mode
 
   # Build the list of repos to disable/enable before calling 'subscription-manager' as it's a very 
   # expensive command to run and hence better to call just once (especially with a long list of repos)

--- a/roles/update-host/tasks/wait-for-host.yml
+++ b/roles/update-host/tasks/wait-for-host.yml
@@ -1,16 +1,6 @@
 ---
 
-- name: "Set the host to wait for"
-  set_fact:
-    update_host: "{{ (hostvars[inventory_hostname]['ansible_host'] is defined) |
-                      ternary(hostvars[inventory_hostname]['ansible_host'],
-                              hostvars[inventory_hostname]['ansible_ssh_host']) }}"
-
 - name: "Waiting for server to come back"
-  local_action: wait_for
-  args:
-    host: "{{ update_host }}"
-    port: 22
+  wait_for_connection:
     delay: 15
     timeout: 300
-    state: started


### PR DESCRIPTION
### What does this PR do?

wait_for_connection is more reliable than wait_for and doesn't need any kind of local magic.

### How should this be tested?

The following works as expected:

```
    - import_role:
        name: ../../galaxy/infra-ansible/roles/update-host
        tasks_from: reboot-host
      vars:
        ansible_become: True
    - import_role:
        name: ../../galaxy/infra-ansible/roles/update-host
        tasks_from: wait-for-host
[... further tasks on the host ...]
```

### Is there a relevant Issue open for this?

n/a

### Other Relevant info, PRs, etc.

The branch of this PR is based on PR #312 's branch (but is independent from it).

### People to notify
cc: @redhat-cop/infra-ansible
