### PR TITLE
Adding back in 'admin-volume-type' for OSP admin

### DIFF
--- a/playbooks/osp/update-osp-cluster-admin.yml
+++ b/playbooks/osp/update-osp-cluster-admin.yml
@@ -3,6 +3,7 @@
 - hosts: infra_osp_hosts
   roles:
     - role: config-software-src
+    - role: osp/admin-volume-type
     - role: osp/admin-nova-flavor
     - role: osp/admin-image
     - role: osp/admin-project


### PR DESCRIPTION
### What does this PR do?
The OSP volume type is *not* handled by the OpenStack Director - hence still need to process this as part of our ansible playbooks. Adding it back in. 

### How should this be tested?
Run the update OSP admin playbook with a valid inventory

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
