### PR TITLE
Adding role to manage/add CA certs to target servers

### DIFF
--- a/playbooks/install-server-ca-cert.yml
+++ b/playbooks/install-server-ca-cert.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: all
+  roles:
+    - manage-server-ca-cert
+

--- a/roles/manage-server-ca-cert/README.md
+++ b/roles/manage-server-ca-cert/README.md
@@ -1,0 +1,38 @@
+manage-server-ca-cert
+=====================
+
+Role used to copy CA certificates to a target server and make them trusted
+
+Requirements
+------------
+
+A Red Hat based Linux OS (RHEL, CentOS, Fedora)
+
+Role Variables
+--------------
+
+| Variable | Description | Required | Defaults | Notes |
+|:--------:|:-----------:|:--------:|:--------:|:-----:|
+|**list_of_additional_ca_certs**|List of CA certificates to be installed|no|(empty list)|**Note:** if no certs are provided, the role will not do anything - useful if the role is part of a bigger playbook|
+|**server_ca_location**|Location to copy the CAs to on the target server|no|/etc/pki/ca-trust/source/anchors/||
+
+
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/manage-server-ca-cert/defaults/main.yml
+++ b/roles/manage-server-ca-cert/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+list_of_additional_ca_certs: []
+server_ca_location: "/etc/pki/ca-trust/source/anchors/"
+

--- a/roles/manage-server-ca-cert/handlers/main.yml
+++ b/roles/manage-server-ca-cert/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: "update trusted ca"
+  command: /bin/update-ca-trust
+  become: yes

--- a/roles/manage-server-ca-cert/tasks/main.yml
+++ b/roles/manage-server-ca-cert/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: "Copy CA cert(s) to target server"
+  copy: 
+    src: "{{ item }}"
+    dest: "{{ server_ca_location }}{{ item|basename }}"
+  loop: "{{ list_of_additional_ca_certs }}"
+  notify:
+    - update trusted ca
+  become: yes


### PR DESCRIPTION
### What does this PR do?
This PR introduces an additional role to install additional CA certs to RHEL based systems (RHEL, CentOS, Fedora, etc.)

### How should this be tested?
Create an inventory for your server(s), use the information from the README to create a list of CA certificates, then run the playbook to get these CAs installed. 

**Note**: to validate, you may want to pick a CA that isn't currently trusted by your server, check that you get an error when running a command to access a target relying on that CA (i.e.: use curl and observe it failing), then run the playbook to install the CA followed by another attempt to access the URL that previously failed.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
