### PR TITLE
Perform initial commit to freshly created bitbucket repositories

### DIFF
--- a/roles/scm/bitbucket.org/tasks/configure-repos.yml
+++ b/roles/scm/bitbucket.org/tasks/configure-repos.yml
@@ -43,6 +43,24 @@
   when:
     - create_repo_output.json.error.message != "Repository with this Slug and Owner already exists."
 
+- name: Perform initial commit (only for freshly created repos)
+  uri:
+    url: "{{ bitbucket_api_url }}/2.0/repositories/{{ repo.team_name }}/{{ repo.repo_name }}/src"
+    method: POST
+    user: "{{ bitbucket_username | b64decode | replace('\n', '') }}"
+    password: "{{ bitbucket_admin_password | b64decode | replace('\n', '') }}"
+    force_basic_auth: yes
+    body: "README.md={{ readme_contents }}&message=Initial%20commit"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    status_code: 200, 201
+  vars:
+    readme_contents: "{{ lookup( 'template', 'README.md.j2')|urlencode }}"
+  tags:
+    - create-repo
+  when:
+    - create_repo_output.status == 200
+
 - name: Add default reviewers for {{ repo.repo_name }}
   uri:
     url: "{{ bitbucket_api_url }}/2.0/repositories/{{ repo.team_name }}/{{ repo.repo_name }}/default-reviewers/{{ item }}"

--- a/roles/scm/bitbucket.org/templates/README.md.j2
+++ b/roles/scm/bitbucket.org/templates/README.md.j2
@@ -1,0 +1,14 @@
+# README #
+
+This is a default `README.md` for `{{ repo.repo_name }}`.
+
+### How to get started with this repository ###
+
+Commits directly to `master` are not allowed.
+
+To commit changes to `master`:
+
+* create a fork or branch of `{{ repo.repo_name }}/master`
+* commit changes to your fork / branch
+* submit a pull request to merge your changes up to `{{ repo.repo_name }}/master` once changes are approved
+


### PR DESCRIPTION
### What does this PR do?
When a new bitbucket repository is freshly created, perform an initial commit to that repository with a simple `README.md` file. This gets around some problems that were encountered by creating a new repository, and then locking down writes to `master`, where it become difficult to commit / merge into `master` in the freshly created repo.

### How should this be tested?
Using the bitbucket.org role, define a repository that does not yet exist.

After running the playbook, and the repository is created, rather than being an empty repository, there should be a basic `README.md` that has been committed as part of an initial commit.

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
No

### People to notify
cc: @redhat-cop/infra-ansible
