### PR TITLE
Allow the base URI for the Nexus REST interface to be overridden for …

### DIFF
--- a/roles/config-nexus/defaults/main.yml
+++ b/roles/config-nexus/defaults/main.yml
@@ -11,6 +11,7 @@ nist_cve_script_name: nist-proxy-repos
 nist_cve_script_file: ../files/nist-proxy-repos.json
 nexus_server_poll_retries: 100
 nexus_server_poll_delay_in_seconds: 5
+nexus_api_base_path: /service/siesta/rest/v1
 nexus_repos:
 - script_name: redhat-repos
   script_file: ../files/redhat-repos.json

--- a/roles/config-nexus/tasks/configure-repos.yml
+++ b/roles/config-nexus/tasks/configure-repos.yml
@@ -2,7 +2,7 @@
 
 - name: "Check For Existing Script: {{ item.script_name }}"
   uri:
-    url: "https://{{ nexus_url }}/service/siesta/rest/v1/script/{{ item.script_name }}"
+    url: "https://{{ nexus_url }}{{ nexus_api_base_path }}/script/{{ item.script_name }}"
     method: GET
     user: "{{ nexus_user }}"
     password: "{{ nexus_password }}"
@@ -13,7 +13,7 @@
 
 - name: "Delete Script if it Exists: {{ item.script_name }}"
   uri:
-    url: "https://{{ nexus_url }}/service/siesta/rest/v1/script/{{ item.script_name }}"
+    url: "https://{{ nexus_url }}{{ nexus_api_base_path }}/script/{{ item.script_name }}"
     method: DELETE
     user: "{{ nexus_user }}"
     password: "{{ nexus_password }}"
@@ -24,7 +24,7 @@
 
 - name: "Create New Script: {{ item.script_name }}"
   uri:
-    url: "https://{{ nexus_url }}/service/siesta/rest/v1/script/"
+    url: "https://{{ nexus_url }}{{ nexus_api_base_path }}/script/"
     method: POST
     user: "{{ nexus_user }}"
     password: "{{ nexus_password }}"
@@ -36,7 +36,7 @@
 
 - name: "Execute New Script: {{ item.script_name }}"
   uri:
-    url: "https://{{ nexus_url }}/service/siesta/rest/v1/script/{{ item.script_name }}/run"
+    url: "https://{{ nexus_url }}{{ nexus_api_base_path }}/script/{{ item.script_name }}/run"
     method: POST
     user: "{{ nexus_user }}"
     password: "{{ nexus_password }}"


### PR DESCRIPTION
…newer versions of Nexus

### What does this PR do?
With the release of Sonatype Nexus >= 3.8, the REST API URI base path has changed. This PR allows overridding the base path using a param of `nexus_api_base_path`, but it defaults to the existing behaviors.

### How should this be tested?
Deploy Nexus >= 3.8 and attempt to run this role with a standard labs-ci-cd inventory and the following playbook:

```
---
- name: Create CI/CD tools
  hosts: tools
  tasks:
    - name: set namespace
      set_fact:
        nexus_namespace: "{{ ci_cd_namespace }}"
        nexus_user: "admin"
        nexus_password: "admin123"
    - include_role:
        name: roles/infra-ansible/roles/config-nexus
      vars:
        nexus_api_base_path: /service/rest/v1
      tags:
        - configure-nexus
```

### Is there a relevant Issue open for this?
resolves  #335 

### People to notify
cc: @redhat-cop/infra-ansible
