### PR TITLE
added conditionals to check for rhsm username and password in prep.yml

### DIFF
--- a/playbooks/prep.yml
+++ b/playbooks/prep.yml
@@ -9,6 +9,15 @@
       register: username
     - set_fact:
         rhsm_username: "{{ username.user_input }}"
+    tags:
+    - configure_rhsm
+    when:
+    - rhsm_register|default(False)
+    - rhsm_activationkey is undefined
+    - rhsm_org_id is undefined
+    - rhsm_username is undefined
+
+  - block:
     - pause:
         prompt: 'Please enter your Red Hat Subscription password'
         echo: no
@@ -23,3 +32,4 @@
     - rhsm_register|default(False)
     - rhsm_activationkey is undefined
     - rhsm_org_id is undefined
+    - rhsm_password is undefined


### PR DESCRIPTION
### What does this PR do?
When rhsm_username and rhsm_password are defined in the inventory, the user will no longer be prompted for these fields.

### How should this be tested?
Try this with any playbook that uses prep.yml with these two variables defined.

### Is there a relevant Issue open for 
#332 

### People to notify
cc: @redhat-cop/infra-ansible
