### PR TITLE
config-docker role ensures that it's mtu matches the default network interface

### DIFF
--- a/roles/config-docker/defaults/main.yml
+++ b/roles/config-docker/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 
 docker_username: root
+
+docker_network_interface: docker0
+
+docker_mtu_offset: 0

--- a/roles/config-docker/defaults/main.yml
+++ b/roles/config-docker/defaults/main.yml
@@ -4,4 +4,10 @@ docker_username: root
 
 docker_network_interface: docker0
 
-docker_mtu_offset: 0
+mtu_offset: 0
+
+docker_interface: docker0
+
+external_interface: default_ipv4
+
+docker_network_file: /etc/sysconfig/docker-network

--- a/roles/config-docker/tasks/docker.yml
+++ b/roles/config-docker/tasks/docker.yml
@@ -23,7 +23,8 @@
   group:
     name: docker
     state: present
-  notify: restart docker
+  notify: 
+  - restart docker
 
 - name: "Add username to the docker group" 
   user:

--- a/roles/config-docker/tasks/main.yml
+++ b/roles/config-docker/tasks/main.yml
@@ -5,3 +5,8 @@
   when: 
   - docker_install|default(False)
 
+- import_tasks: mtu.yml
+  when: 
+  - docker_install|default(False)
+  - check_mtu|default(True)
+

--- a/roles/config-docker/tasks/main.yml
+++ b/roles/config-docker/tasks/main.yml
@@ -1,12 +1,11 @@
 ---
 
-- name: "Install, configure and enable Docker"
-  import_tasks: docker.yml
+- block:
+  - name: "Install, configure and enable Docker"
+    import_tasks: docker.yml
+  
+  - name: "Configure docker mtu"
+    import_tasks: mtu.yml
   when: 
   - docker_install|default(False)
-
-- import_tasks: mtu.yml
-  when: 
-  - docker_install|default(False)
-  - check_mtu|default(True)
 

--- a/roles/config-docker/tasks/mtu.yml
+++ b/roles/config-docker/tasks/mtu.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Refresh facts for updated docker information
+  setup:
+
+- name: Find difference in mtu between the default ipv4 and docker devices
+  set_fact:
+    mtu_diff: "{{ ansible_facts.default_ipv4.mtu - ansible_facts.docker0.mtu }}"
+
+- name: Change docker mtu to ipv4 default
+  lineinfile:
+    path: /etc/sysconfig/docker-network
+    regexp: '^DOCKER_NETWORK_OPTIONS='
+    line: "DOCKER_NETWORK_OPTIONS=' --mtu={{ ansible_facts.default_ipv4.mtu }}'"
+  when: mtu_diff != 0
+  notify: restart docker

--- a/roles/config-docker/tasks/mtu.yml
+++ b/roles/config-docker/tasks/mtu.yml
@@ -1,49 +1,30 @@
 ---
 
-- name: Refresh facts for updated docker information
-  setup:
-
-- name: Find difference in mtu between the default ipv4 and docker devices
+- name: "Set Docker MTU based on parameters" 
   set_fact:
-    mtu_diff: "{{ ansible_facts.default_ipv4.mtu - ansible_facts[lookup('vars','docker_network_interface')].mtu }}"
+    new_mtu: "{{ ansible_facts[external_interface].mtu - mtu_offset|int }}"
 
-- name: Check if file has mtu set 
-  command: grep -q "mtu=" /etc/sysconfig/docker-network
-  register: docker_mtu_set_check
-  check_mode: no
-  ignore_errors: yes 
-  changed_when: no
+- name: "Check if the entry exists in the file"
+  lineinfile:
+    path: "{{ docker_network_file }}"
+    regexp: '^DOCKER_NETWORK_OPTIONS=".*"$'
+    state: absent
+  check_mode: yes
+  register: mtu_config_exists
 
-- name: Update the mtu if previously set 
-  replace:
-    path: /etc/sysconfig/docker-network
-    regexp: '--mtu=[0-9]\d*'
-    replace: "--mtu={{ ansible_facts.default_ipv4.mtu - docker_mtu_offset }}"
-  when: 
-  - docker_mtu_set_check.rc == 0
-  notify: 
-  - restart docker
-  
 - block:
-  - name: Append mtu option
+  - name: "Update file based on mtu_diff - mtu_offset"
     replace:
-      path: /etc/sysconfig/docker-network
-      regexp: '^DOCKER_NETWORK_OPTIONS=(.*)$'
-      replace: 'DOCKER_NETWORK_OPTIONS=\1 --mtu={{ ansible_facts.default_ipv4.mtu - docker_mtu_offset }}'
-
-  - name: Format file arguments 
-    replace:
-      path: /etc/sysconfig/docker-network 
-      regexp: "'" 
-      replace: ""
-
-  - name: Format file arguments
-    replace:
-      path: /etc/sysconfig/docker-network
-      regexp: "^DOCKER_NETWORK_OPTIONS=(.*)"
-      replace: DOCKER_NETWORK_OPTIONS='\1'
-    notify: 
-    - restart docker    
+      path: "{{ docker_network_file }}"
+      regexp: '^DOCKER_NETWORK_OPTIONS="\s*(.*(?=--mtu=\d+))(--mtu=\d+)\s*(.*)"$|^DOCKER_NETWORK_OPTIONS="(.*)"$'
+      replace: 'DOCKER_NETWORK_OPTIONS="\1 --mtu={{ new_mtu }} \3\4"'
+    when:
+    - mtu_config_exists.found
+  - name: "Add line if it wasn't updated above"
+    lineinfile:
+      path: "{{ docker_network_file }}"
+      line: 'DOCKER_NETWORK_OPTIONS="--mtu={{ new_mtu }}"'
+    when:
+    - not mtu_config_exists.found
   when:
-  - docker_mtu_set_check.rc == 1
-  
+  - new_mtu != ansible_facts[docker_interface].mtu

--- a/roles/config-docker/tasks/mtu.yml
+++ b/roles/config-docker/tasks/mtu.yml
@@ -5,12 +5,45 @@
 
 - name: Find difference in mtu between the default ipv4 and docker devices
   set_fact:
-    mtu_diff: "{{ ansible_facts.default_ipv4.mtu - ansible_facts.docker0.mtu }}"
+    mtu_diff: "{{ ansible_facts.default_ipv4.mtu - ansible_facts[lookup('vars','docker_network_interface')].mtu }}"
 
-- name: Change docker mtu to ipv4 default
-  lineinfile:
+- name: Check if file has mtu set 
+  command: grep -q "mtu=" /etc/sysconfig/docker-network
+  register: docker_mtu_set_check
+  check_mode: no
+  ignore_errors: yes 
+  changed_when: no
+
+- name: Update the mtu if previously set 
+  replace:
     path: /etc/sysconfig/docker-network
-    regexp: '^DOCKER_NETWORK_OPTIONS='
-    line: "DOCKER_NETWORK_OPTIONS=' --mtu={{ ansible_facts.default_ipv4.mtu }}'"
-  when: mtu_diff != 0
-  notify: restart docker
+    regexp: '--mtu=[1-9]\d*'
+    replace: "--mtu={{ ansible_facts.default_ipv4.mtu - docker_mtu_offset }}"
+  when: 
+  - docker_mtu_set_check.rc == 0
+  notify: 
+  - restart docker
+  
+- block:
+  - name: Append mtu option
+    replace:
+      path: /etc/sysconfig/docker-network
+      regexp: '^DOCKER_NETWORK_OPTIONS=(.*)$'
+      replace: 'DOCKER_NETWORK_OPTIONS=\1 --mtu={{ ansible_facts.default_ipv4.mtu - docker_mtu_offset }}'
+
+  - name: Format file arguments 
+    replace:
+      path: /etc/sysconfig/docker-network 
+      regexp: "'" 
+      replace: ""
+
+  - name: Format file arguments
+    replace:
+      path: /etc/sysconfig/docker-network
+      regexp: "^DOCKER_NETWORK_OPTIONS=(.*)"
+      replace: DOCKER_NETWORK_OPTIONS='\1'
+    notify: 
+    - restart docker    
+  when:
+  - docker_mtu_set_check.rc == 1
+  

--- a/roles/config-docker/tasks/mtu.yml
+++ b/roles/config-docker/tasks/mtu.yml
@@ -17,7 +17,7 @@
 - name: Update the mtu if previously set 
   replace:
     path: /etc/sysconfig/docker-network
-    regexp: '--mtu=[1-9]\d*'
+    regexp: '--mtu=[0-9]\d*'
     replace: "--mtu={{ ansible_facts.default_ipv4.mtu - docker_mtu_offset }}"
   when: 
   - docker_mtu_set_check.rc == 0


### PR DESCRIPTION
### What does this PR do?
Sometimes the mtu of the docker interface and the default one do not match after running this role. This can cause certain requests to hang indefinitely. This pr will check the values of both and ensure that they match after installation. 

### How should this be tested?
Run a playbook using this role. Preferably against a host where you know that the two mtu values will not match. 

### People to notify
cc: @redhat-cop/infra-ansible
