### PR TITLE
Idm password resets

### DIFF
--- a/roles/identity-management/manage-idm-identities/README.md
+++ b/roles/identity-management/manage-idm-identities/README.md
@@ -13,6 +13,7 @@ Role Variables
 |**ipa_admin_user**|The IPA/IdM admin user with proper permissions to administer identities|yes|N/A|
 |**ipa_admin_password**|The IPA/IdM admin password for the above mentioned admin user|yes|N/A|
 |**ipa_validate_certs**|Whether to validate the IPA/IdM certificate|no|True|
+|**ipa_password_reset_users**|A list of users who's passwords you wish to reset|no|[]|
 
 In addition to the above mentioned variables, the role also requires an `identity` dictionary with a list of users and groups as documented in the [identity-management README](../README.md).
 

--- a/roles/identity-management/manage-idm-identities/defaults/main.yml
+++ b/roles/identity-management/manage-idm-identities/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+ipa_password_reset_users: []

--- a/roles/identity-management/manage-idm-identities/filter_plugins/set-user-flags.py
+++ b/roles/identity-management/manage-idm-identities/filter_plugins/set-user-flags.py
@@ -1,14 +1,20 @@
-def set_user_flags(entry):
+def set_user_flags(entry, password_reset_users):
 
     data = {
         'generate_password': False,
         'notify_user': False
     }
 
-    if 'user' in entry.keys() and 'has_password' in entry['user'].keys() and entry['user']['has_password'] == False:
+    # flag if user's password has never been set
+    no_password = 'user' in entry.keys() and 'has_password' in entry['user'].keys() and entry['user']['has_password'] == False
+
+    # flag if password reset has been requested for user
+    passowrd_reset_requested = 'user' in entry.keys() and entry['user']['uid'][0] in password_reset_users
+
+    if no_password or passowrd_reset_requested:
         data['generate_password'] = True
         data['notify_user'] = True
-
+        
     return data
 
 

--- a/roles/identity-management/manage-idm-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-idm-identities/tasks/create_users.yml
@@ -31,7 +31,7 @@
 
     - name: "Create password generation dataset"
       set_fact:
-         list_of_users: "{{ list_of_users + [ idm_data.user_data|combine(idm_data|set_user_flags) ] }}"
+         list_of_users: "{{ list_of_users + [ idm_data.user_data|combine(idm_data|set_user_flags(ipa_password_reset_users)) ] }}"
       with_items:
         - "{{ idm_user_list.results }}"
       loop_control:


### PR DESCRIPTION
### What does this PR do?
Added ability to reset passwords in idm.

### How should this be tested?
Password resets can be tested by setting the ipa_password_reset_users variable:

`ansible-playbook -i inventory playbooks/manage-identities/process-and-notify-users.yml -e 'ipa_password_reset_users=["userzero","userone"]'`

### Other Relevant info, PRs, etc.
#348 <- Must be added first to fix idm playbooks

### People to notify
cc: @redhat-cop/infra-ansible
