### PR TITLE
changed nexus waiting to https

### DIFF
--- a/roles/config-nexus/tasks/wait-for-nexus.yml
+++ b/roles/config-nexus/tasks/wait-for-nexus.yml
@@ -2,7 +2,7 @@
 
 - name: "Ensure the Nexus Server is Up"
   uri:
-    url: "http://{{ nexus_url }}/service/metrics/healthcheck"
+    url: "https://{{ nexus_url }}/service/metrics/healthcheck"
     method: GET
     status_code: 200
     user: "{{ nexus_user }}"


### PR DESCRIPTION
### What does this PR do?
When waiting for nexus to appear after it's configuration, the config-nexus role would use http instead of https. This corrects it. 

### How should this be tested?
Use this role and ensure that it doesn't fail on the "Ensure the Nexus Server is Up" step. 

### Is there a relevant Issue open for this?
resolves #362 

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
