### PR TITLE
Change nexus healthcheck endpoint

### DIFF
--- a/roles/config-nexus/tasks/wait-for-nexus.yml
+++ b/roles/config-nexus/tasks/wait-for-nexus.yml
@@ -2,7 +2,7 @@
 
 - name: "Ensure the Nexus Server is Up"
   uri:
-    url: "http://{{ nexus_url }}/service/metrics/healthcheck"
+    url: "http://{{ nexus_url }}/service/metrics/ping"
     method: GET
     status_code: 200
     user: "{{ nexus_user }}"


### PR DESCRIPTION
### What does this PR do?
As mentioned in #365, using the `service/metrics/healthcheck` endpoint will cause the `wait-for-nexus` task to timeout because it returns a 500 error until the default password is reset. Since this task is run in order to verify that the app is up and running (and prior to any modifications being made) -- this will always break. This PR changes the endpoint to use `service/metrics/ping` which accomplishes the same goal and allows us to move forward to make any of the required modifications.

### How should this be tested?
Run the current role -- you'll see that it currently times out waiting for the app to become ready. Run the test found in this current PR (with the ping endpoint change made) and you'll see that the wait returns and allows moving forward with configuration.

### Is there a relevant Issue open for this?

resolves #365 

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
