### PR TITLE
Fixed NVD switched to HTTPS issue

### DIFF
--- a/roles/config-clair/README.md
+++ b/roles/config-clair/README.md
@@ -12,7 +12,7 @@ This role contains a number of variables to customize the deployment of Clair. T
 
 | Name | Description | Default|
 |---|---|---|
-|clair_image|Clair image|`quay.io/coreos/clair-jwt:v2.0.4`|
+|clair_image|Clair image|`quay.io/coreos/clair-jwt:v2.0.8`|
 |clair_config_dir|Directory for Clair configurations| `/var/lib/clair/config`| 
 |clair_host_proxy_port|Port to the clair proxy on the host |`6060`|
 |clair_host_api_port|Port to the clair API on the host |`6061`|

--- a/roles/config-clair/defaults/main.yml
+++ b/roles/config-clair/defaults/main.yml
@@ -10,7 +10,7 @@ systemd_service_dir: /usr/lib/systemd/system
 systemd_environmentfile_dir: /etc/sysconfig
 
 # Clair
-clair_image: quay.io/coreos/clair-jwt:v2.0.4
+clair_image: quay.io/coreos/clair-jwt:v2.0.8
 clair_config_dir: /var/lib/clair/config
 clair_container_config_dir: /config
 clair_ssl_trust_configure: False


### PR DESCRIPTION
Signed-off-by: Phil Huang <phil.huang@redhat.com>

### What does this PR do?
NVD stopped provide HTTPS traffic and switched to HTTPS and updated `clair-jwt` v2.0.7+ can resolve the issue


### How should this be tested?
Will not show `could not get NVD data feed hash` in clair-jwt log

### Is there a relevant Issue open for this?

### Other Relevant info, PRs, etc.
https://github.com/coreos/clair/pull/565
https://github.com/coreos/clair/issues/515

### People to notify
cc: @redhat-cop/infra-ansible
