### PR TITLE
auxiliary playbook for updating certs in ansible-tower

### DIFF
--- a/playbooks/ansible/tower/README.md
+++ b/playbooks/ansible/tower/README.md
@@ -28,6 +28,12 @@ Any consecutive runs can be done without the tags to speed up execution:
 > ansible-playbook -i inventory configure-ansible-tower.yml
 ```
 
+To update certificates after expiration: 
+```bash
+> ansible-playbook -i inventory install-tower-cert.yml
+```
+Be sure that your inventory points to new certificates. If you are using Let's Encrypt for your CA you can use the [generate-lets-encrypt-cert](../../certs/generate-lets-encrypt-cert.yml) playbook. 
+
 
 License
 -------

--- a/playbooks/ansible/tower/update-tower-cert.yml
+++ b/playbooks/ansible/tower/update-tower-cert.yml
@@ -2,17 +2,7 @@
 
 - hosts: ansible-tower
   tasks:
-  - name: "Copy custom Tower SSL certificate and Key"
-    block:
-      - copy:
-          src: "{{ ansible_tower.install.ssl_certificate.cert }}"
-          dest: /etc/tower/tower.cert
+  - import_role:
+      name: ansible/tower/config-ansible-tower
+      tasks_from: install-cert
 
-      - copy:
-          src: "{{ ansible_tower.install.ssl_certificate.key }}"
-          dest: /etc/tower/tower.key
-
-      - service:
-          name: supervisord
-          state: restarted
-    become: true

--- a/playbooks/ansible/tower/update-tower-cert.yml
+++ b/playbooks/ansible/tower/update-tower-cert.yml
@@ -1,0 +1,18 @@
+---
+
+- hosts: ansible-tower
+  tasks:
+  - name: "Copy custom Tower SSL certificate and Key"
+    block:
+      - copy:
+          src: "{{ ansible_tower.install.ssl_certificate.cert }}"
+          dest: /etc/tower/tower.cert
+
+      - copy:
+          src: "{{ ansible_tower.install.ssl_certificate.key }}"
+          dest: /etc/tower/tower.key
+
+      - service:
+          name: supervisord
+          state: restarted
+    become: true

--- a/roles/ansible/tower/config-ansible-tower/tasks/install-cert.yml
+++ b/roles/ansible/tower/config-ansible-tower/tasks/install-cert.yml
@@ -1,0 +1,18 @@
+---
+
+- name: "Copy custom Tower SSL certificate and Key"
+  block:
+  - copy:
+      src: "{{ ansible_tower.install.ssl_certificate.cert }}"
+      dest: /etc/tower/tower.cert
+    notify:
+    - restart-tower
+
+  - copy:
+      src: "{{ ansible_tower.install.ssl_certificate.key }}"
+      dest: /etc/tower/tower.key
+    notify:
+    - restart-tower
+  when:
+  - ansible_tower.install.ssl_certificate is defined
+  become: True

--- a/roles/ansible/tower/config-ansible-tower/tasks/install.yml
+++ b/roles/ansible/tower/config-ansible-tower/tasks/install.yml
@@ -40,19 +40,4 @@
     when:
     - ansible_tower_oc_download_url|trim != ''
 
-  - name: "Copy custom Tower SSL certificate and Key"
-    block:
-      - copy:
-          src: "{{ ansible_tower.install.ssl_certificate.cert }}"
-          dest: /etc/tower/tower.cert
-        notify:
-        - restart-tower
-      - copy:
-          src: "{{ ansible_tower.install.ssl_certificate.key }}"
-          dest: /etc/tower/tower.key
-        notify:
-        - restart-tower
-    when:
-    - ansible_tower.install.ssl_certificate is defined
-
   become: True

--- a/roles/ansible/tower/config-ansible-tower/tasks/main.yml
+++ b/roles/ansible/tower/config-ansible-tower/tasks/main.yml
@@ -1,3 +1,5 @@
 ---
 
 - import_tasks: install.yml
+
+- import_tasks: install-cert.yml


### PR DESCRIPTION
### What does this PR do?
Adds playbook for updating ansible-tower certificates after expiration. 

### How should this be tested?
If possible, this would be best tested against an ansible-tower instance with an expired certificate. You can run it with the same inventory used to provision so long as the `ansible-tower.install.ssl_certificate.cert` and `ansible-tower.install.ssl_certificate.key` files have been updated. 

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
