### PR TITLE
WIP - add code for skip nexus failure

### DIFF
--- a/roles/config-nexus/defaults/main.yml
+++ b/roles/config-nexus/defaults/main.yml
@@ -13,6 +13,7 @@ nexus_server_poll_retries: 100
 nexus_server_poll_delay_in_seconds: 5
 nexus_api_base_path: /service/siesta/rest/v1
 nexus_validate_certs: true
+nexus_skip_wait_failure: true
 nexus_repos:
 - script_name: redhat-repos
   script_file: ../files/redhat-repos.json

--- a/roles/config-nexus/tasks/main.yml
+++ b/roles/config-nexus/tasks/main.yml
@@ -20,9 +20,9 @@
   include_tasks: configure-repos.yml
   with_items:
   - "{{ nexus_repos | default([]) }}"
-  when: nexus_server_check_result.status == 200 || nexus_skip_wait_failure == false
+  when: nexus_server_check_result.status != -1
 
 - name: "Gracefully Fail"
   debug:
     msg: Nexus Server STILL isn't up, scripts were NOT curled in. Please try again at a later time.
-  when: nexus_server_check_result != 200
+  when: nexus_server_check_result.status == -1

--- a/roles/config-nexus/tasks/main.yml
+++ b/roles/config-nexus/tasks/main.yml
@@ -20,4 +20,9 @@
   include_tasks: configure-repos.yml
   with_items:
   - "{{ nexus_repos | default([]) }}"
+  when: nexus_server_check_result.status == 200 || nexus_skip_wait_failure == false
 
+- name: "Gracefully Fail"
+  debug:
+    msg: Nexus Server STILL isn't up, scripts were NOT curled in. Please try again at a later time.
+  when: nexus_server_check_result != 200

--- a/roles/config-nexus/tasks/wait-for-nexus.yml
+++ b/roles/config-nexus/tasks/wait-for-nexus.yml
@@ -13,4 +13,4 @@
   until: nexus_server_check_result is success
   retries: '{{ nexus_server_poll_retries }}'
   delay: '{{ nexus_server_poll_delay_in_seconds }}'
-
+  ignore_errors: "{{ nexus_skip_wait_failure }}"


### PR DESCRIPTION
### What does this PR do?
give the option to "soft" fail when nexus can't be reached

### How should this be tested?
Run a playbook with the role, nexus URL really shouldn't matter since it would fail if it doesn't exist. Success needs a running nexus

### Is there a relevant Issue open for this?
https://github.com/rht-labs/labs-ci-cd/issues/279

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
