### PR TITLE
Use default empty variables parameter for tower inventory, fixes #384

### DIFF
--- a/roles/ansible/tower/manage-inventories/templates/inventory.j2
+++ b/roles/ansible/tower/manage-inventories/templates/inventory.j2
@@ -2,5 +2,5 @@
     "name": "{{ inventory.name }}",
     "description": "{{ inventory.description | default('') }}",
     "organization": {{ org_id }},
-    "variables": "{{ inventory.variables }}"
+    "variables": "{{ inventory.variables | default('') }}"
 }


### PR DESCRIPTION
### What does this PR do?
Let the `variables` parameter not be required, which is what the README says.

### How should this be tested?
Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #384 

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
