### PR TITLE
Support credential inputs in Ansible Tower

### DIFF
--- a/roles/ansible/tower/manage-credentials/README.md
+++ b/roles/ansible/tower/manage-credentials/README.md
@@ -19,9 +19,12 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.credentials.description|Description for the credential|no|nothing('')|
 |ansible_tower.credentials.organization|Name of the existing org to tie these credentials with|yes||
 |ansible_tower.credentials.type|Type of credentials ('machine', 'aws', etc)|yes||
+|ansible_tower.credentials.inputs|Additional input parameters|no||
 
 
 **_Note:_** Credential configuration will **only** happen if the `ansible_tower.credentials` portion of the dictionary is defined. Likewise, the installation expects this section to be "complete" if specified as it otherwise may error out.
+
+**_Note:_** Credential input will **only** happen if the `ansible_tower.credentials.inputs` portion of the dictionary is defined and complete as per [Tower Credential Types documentation](https://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#credential-types).
 
 
 ## Example Inventory
@@ -39,6 +42,15 @@ ansible_tower:
     description: "My Credential 2"
     organization: "Default"
     credential_type: "Machine"
+  - name: "Cred3"
+    description: "My Credential 3"
+    organization: "Default"
+    credential_type: "Ansible Tower"
+    inputs:
+      host: "localhost"
+      username: "my_user"
+      password: 'my_password'
+      verify_ssl: true
 ```
 
 ## Example Playbook

--- a/roles/ansible/tower/manage-credentials/templates/credential.j2
+++ b/roles/ansible/tower/manage-credentials/templates/credential.j2
@@ -5,5 +5,9 @@
     "user": null,
     "team": null,
     "credential_type": {{ credential_type_id }},
+    {% if credential.inputs | length > 0 -%}
+    "inputs": {{ credential.inputs | to_json }}
+    {% else -%}
     "inputs": {}
+    {% endif -%}
 }

--- a/roles/ansible/tower/manage-job-templates/README.md
+++ b/roles/ansible/tower/manage-job-templates/README.md
@@ -21,7 +21,7 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.job_templates.project|The name of the project to be used with this Job Template|yes||
 |ansible_tower.job_templates.playbook|Name of the playbook to be called when the job is launched|yes||
 |ansible_tower.job_templates.credential|Name of the credential to be used with this Job Template|yes||
-|ansible_tower.job_templates.ask_variable_on_launch|Does this Job Template accept input variable at runtime|no|false|
+|ansible_tower.job_templates.ask_variables_on_launch|Does this Job Template accept input variables at runtime|no|false|
 |ansible_tower.job_templates.extra_vars|Extra Variables to be passed at runtime|no|nothing('')|
 |ansible_tower.job_templates.permissions|Permissions to run the job (see below)|no||
 


### PR DESCRIPTION
### What does this PR do?
Add support for inputs in [Ansible Tower credential types](https://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#credential-types)

### How should this be tested?
Use the `manage-credentials` role and the following inventory
```
ansible_tower:
  admin_password: 'admin_pw'
  ...
  credentials:
  - name: my-tower-cred
    organization: my-tower-org
    credential_type: Ansible Tower
    inputs:
      host: localhost
      username: admin
      password: 'admin_pw'
      verify_ssl: true
```

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
