### PR TITLE
Add config-packages role to configure-ansible-tower playbook

### DIFF
--- a/playbooks/ansible/tower/configure-ansible-tower.yml
+++ b/playbooks/ansible/tower/configure-ansible-tower.yml
@@ -2,6 +2,7 @@
 
 - hosts: ansible-tower
   roles:
+  - role: config-packages
   - role: ansible/tower/config-ansible-tower
   - role: ansible/tower/config-ansible-tower-license
   - role: ansible/tower/config-ansible-tower-ldap


### PR DESCRIPTION
### What does this PR do?
This will let you install additional/optional packages on your tower host

### How should this be tested?
Add a section to your inventory
```
---
list_of_packages_to_install:
  - python2-ansible-tower-cli
  - awscli
```
The playbook will now install these packages on your tower host.

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
