### PR TITLE
Move config-packages until after Tower is installed

### DIFF
--- a/playbooks/ansible/tower/configure-ansible-tower.yml
+++ b/playbooks/ansible/tower/configure-ansible-tower.yml
@@ -2,10 +2,10 @@
 
 - hosts: ansible-tower
   roles:
-  - role: config-packages
   - role: ansible/tower/config-ansible-tower
   - role: ansible/tower/config-ansible-tower-license
   - role: ansible/tower/config-ansible-tower-ldap
+  - role: config-packages
   tags:
   - 'never'
   - 'install'


### PR DESCRIPTION
### What does this PR do?
The Tower installation enables additional yum repos which can't be used until post install

### How should this be tested?
This was tested with `python2-ansible-tower-cli` package which will not be available until post tower install.

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
