### PR TITLE
Support multiple job template credentials and credentials without SSH keys

### DIFF
--- a/roles/ansible/tower/manage-job-templates/README.md
+++ b/roles/ansible/tower/manage-job-templates/README.md
@@ -20,7 +20,8 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.job_templates.inventory|The name of the inventory to be used with this Job Template|yes||
 |ansible_tower.job_templates.project|The name of the project to be used with this Job Template|yes||
 |ansible_tower.job_templates.playbook|Name of the playbook to be called when the job is launched|yes||
-|ansible_tower.job_templates.credential|Name of the credential to be used with this Job Template|yes||
+|ansible_tower.job_templates.credential|Deprecated, see `ansible_tower.job_templates.credentials`|no||
+|ansible_tower.job_templates.credentials|List of credentials to be used with this Job Template|no||
 |ansible_tower.job_templates.ask_variables_on_launch|Does this Job Template accept input variables at runtime|no|false|
 |ansible_tower.job_templates.extra_vars|Extra Variables to be passed at runtime|no|nothing('')|
 |ansible_tower.job_templates.permissions|Permissions to run the job (see below)|no||
@@ -60,7 +61,8 @@ ansible_tower:
     inventory: "Inventory1"
     project: "Project1"
     playbook: "playbooks/prep.yml"
-    credential: "Cred1"
+    credential:
+    - "Cred1"
     extra_vars: "---\\nhello: world\\n"
     ask_variables_on_launch: true
     permissions:

--- a/roles/ansible/tower/manage-job-templates/README.md
+++ b/roles/ansible/tower/manage-job-templates/README.md
@@ -61,7 +61,7 @@ ansible_tower:
     inventory: "Inventory1"
     project: "Project1"
     playbook: "playbooks/prep.yml"
-    credential:
+    credentials:
     - "Cred1"
     extra_vars: "---\\nhello: world\\n"
     ask_variables_on_launch: true

--- a/roles/ansible/tower/manage-job-templates/tasks/process-job-template-credentials.yml
+++ b/roles/ansible/tower/manage-job-templates/tasks/process-job-template-credentials.yml
@@ -1,0 +1,27 @@
+---
+
+- name: "Get the credential id based on the credential name"
+  set_fact:
+    credential_id: "{{ item.id }}"
+  when:
+  - item.name|trim == job_template_credential|trim
+  loop: "{{ existing_credentials_output.rest_output }}"
+
+- name: "Add credential to job_template"
+  uri:
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/job_templates/{{ job_template_id }}/credentials/"
+    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+    password: "{{ ansible_tower.admin_password }}"
+    force_basic_auth: yes
+    method: POST
+    body: '{ "id": {{ credential_id | int }} }'
+    body_format: 'json'
+    headers:
+      Content-Type: "application/json"
+      Accept: "application/json"
+    validate_certs: no
+    status_code: 204,400
+
+- name: "Clear/Update facts"
+  set_fact:
+    credential_id: ''

--- a/roles/ansible/tower/manage-job-templates/tasks/process-job-template.yml
+++ b/roles/ansible/tower/manage-job-templates/tasks/process-job-template.yml
@@ -16,28 +16,44 @@
   with_items:
   - "{{ existing_projects_output.rest_output }}"
 
-- name: "Get the credential id based on the credential name"
+- name: "Get the job template id based on job template name"
   set_fact:
-    credential_id: "{{ item.id }}"
+    job_template_id: "{{ item.id }}"
   when:
-  - item.name|trim == job_template.credential|trim
+  - item.name|trim == job_template.name|trim
   with_items:
-  - "{{ existing_credentials_output.rest_output }}"
+  - "{{ existing_job_templates_output.rest_output }}"
 
 - name: "Load up the job template"
-  uri:
-    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/job_templates/"
-    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-    password: "{{ ansible_tower.admin_password }}"
-    force_basic_auth: yes
-    method: POST
-    body: "{{ lookup('template', 'job-template.j2') }}"
-    body_format: 'json'
-    headers:
-      Content-Type: "application/json"
-      Accept: "application/json"
-    validate_certs: no
-    status_code: 200,201,400
+  block:
+  - name: "Create job template {{ job_template.name }}"
+    uri:
+      url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/job_templates/"
+      user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+      password: "{{ ansible_tower.admin_password }}"
+      force_basic_auth: yes
+      method: POST
+      body: "{{ lookup('template', 'job-template.j2') }}"
+      body_format: 'json'
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      validate_certs: no
+      status_code: 200,201,400
+    register: job_template_creation_output
+
+  - name: "Get the created job template id"
+    set_fact:
+      job_template_id: "{{ job_template_creation_output.json.id }}"
+  when:
+  - job_template_id is not defined
+
+- name: "Add credentials to job template: {{ job_template.name }}"
+  include_tasks: process-job-template-credentials.yml
+  loop: "{{ job_template.credentials | default([ job_template.credential|trim ]) }}"
+  loop_control:
+    loop_var: job_template_credential
+  when: (job_template.credentials is defined) or (job_template.credential is defined)
 
 # Utilize the `rest_get` library routine to ensure REST pagination is handled
 - name: "Obtain the current roles"

--- a/roles/ansible/tower/manage-job-templates/templates/job-template.j2
+++ b/roles/ansible/tower/manage-job-templates/templates/job-template.j2
@@ -5,7 +5,7 @@
     "inventory": {{ inventory_id }},
     "project": {{ project_id }},
     "playbook": "{{ job_template.playbook }}",
-    "credential": {{ credential_id }},
+    "credential": null,
     "vault_credential": null,
     "forks": 0,
     "limit": "",

--- a/roles/ansible/tower/manage-job-templates/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/manage-job-templates/tests/inventory/group_vars/tower.yml
@@ -18,3 +18,19 @@ ansible_tower:
       users:
       - name: user1
         role: Execute
+  - name: "Job 2"
+    description: "My Job 2"
+    inventory: "Inventory1"
+    project: "Project1"
+    playbook: "playbooks/prep.yml"
+    credentials:
+    - "Cred1"
+    extra_vars: "---\\nhello: world\\n"
+    ask_variables_on_launch: true
+    permissions:
+      teams:
+      - name: team1
+        role: Execute
+      users:
+      - name: user1
+        role: Execute


### PR DESCRIPTION
### What does this PR do?
The tower job_template API will not let you add a credential without an SSH key.
```
POST /api/v2/job_templates/

HTTP 400 Bad Request
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept
X-API-Node: localhost
X-API-Time: 0.020s

{
    "credential": [
        "You must provide an SSH credential."
    ]
}
```

Tower does support job template credentials without SSH keys through the UI. This can also be accomplished through the API by using:
```
POST /api/v2/job_templates/<job_template_id>/credentials/
```
This endpoint also allows adding multiple credentials to a job template which is also supported in the Tower UI.
This PR will change the inventory job template credential variable, see the updated README. However, backwards compatibility is being maintained in order not to break existing implementations.

### How should this be tested?
Run the existing tests

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
