### PR TITLE
Remove ocp specifics from tower license role

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-license/README.md
+++ b/roles/ansible/tower/config-ansible-tower-license/README.md
@@ -1,0 +1,52 @@
+config-ansible-tower-license
+=========================
+
+This role is used to provide an Ansible Tower instance with a license
+
+## Requirements
+
+A running Ansible Tower with admin permission level access.
+
+
+## Role Variables
+
+The variables used to configure Ansible Tower LDAP are outlined in the table below.
+
+| Variable | Description | Required | Defaults |
+|:---------|:------------|:---------|:---------|
+|ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
+|ansible_tower.admin_username|Admin username for the Ansible Tower install|yes||
+|ansible_tower.install.license_file|Path to valid Ansible Tower license content|yes||
+
+
+
+## Example Inventory
+```yaml
+ansible_tower:
+  admin_username: "admin"
+  admin_password: "admin123"
+  install:
+    license_file: "{{ inventory_dir }}/../files/example-license.json"
+```
+
+## Example Playbook
+
+```yaml
+---
+
+- hosts: tower
+  roles:
+  - role: config-ansible-tower-license
+```
+
+
+License
+-------
+
+Apache License 2.0
+
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/ansible/tower/config-ansible-tower-license/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 
-kubernetes_deployment_name: ansible-tower

--- a/roles/ansible/tower/config-ansible-tower-license/tasks/license.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/tasks/license.yml
@@ -1,7 +1,5 @@
 ---
 
-- block:
-
 - name: "Wait for Tower to become available before proceeding (30 sec max)"
   uri:
     url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"

--- a/roles/ansible/tower/config-ansible-tower-license/tasks/license.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/tasks/license.yml
@@ -1,16 +1,6 @@
 ---
 
 - block:
-  - name: Get Route Info
-    shell: "oc get route -n ansible-tower {{ kubernetes_deployment_name }}-web-svc -o json"
-    register: route
-  - set_fact:
-      route: "{{ route.stdout | from_json }}"
-  - set_fact:
-      default_ansible_tower_url: "{{ route.spec.port.targetPort }}://{{ route.spec.host }}"
-  when:
-  - default_ansible_tower_url is undefined
-  - ansible_tower.url is undefined
 
 - name: "Wait for Tower to become available before proceeding (30 sec max)"
   uri:

--- a/roles/ansible/tower/config-ansible-tower-license/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/tests/inventory/group_vars/tower.yml
@@ -8,10 +8,6 @@ ansible_connection: local
 ansible_tower:
   admin_username: "admin"
   admin_password: "secret"
-  pg_username: "awx"
-  pg_password: "redhat"
-  rabbitmq_password: "secret"
-  secret_key: "mysecrettoken"
-  rabbitmq_erlang_cookie: "secret"
+  url: https://tower.example.com
   install:
     license_file: "{{ inventory_dir }}/../files/example-license.json"

--- a/roles/ansible/tower/config-ansible-tower-license/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/tests/inventory/group_vars/tower.yml
@@ -6,9 +6,6 @@ ansible_connection: local
 #       - please replace with valid values and files
 
 ansible_tower:
-  openshift_host: https://console.openshift.local
-  openshift_user: "admin"
-  openshift_password: "secret"
   admin_username: "admin"
   admin_password: "secret"
   pg_username: "awx"
@@ -18,4 +15,3 @@ ansible_tower:
   rabbitmq_erlang_cookie: "secret"
   install:
     license_file: "{{ inventory_dir }}/../files/example-license.json"
-

--- a/roles/ansible/tower/config-ansible-tower-license/tests/test.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/tests/test.yml
@@ -2,5 +2,4 @@
 
 - hosts: tower
   roles:
-  - role: ansible/tower/config-ansible-tower-ocp
   - role: ansible/tower/config-ansible-tower-license


### PR DESCRIPTION
### What does this PR do?
This removes the ocp specifics from the ansible tower license role. Previously if `ansible_tower.url` or `default_tower_url` weren't set, it just assumed that it was running on OCP and then figured out the route. With some of the additional roles that we're looking to add, I've removed this to bring it in line with our other ansible_tower roles.

### How should this be tested?
Run tests in tests directory

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
