### PR TITLE
Fix deprecated options for Satellite Install

### DIFF
--- a/roles/config-satellite/tasks/install.yml
+++ b/roles/config-satellite/tasks/install.yml
@@ -2,11 +2,11 @@
 
 - name: "Install Satellite with default parameters"
   command: > 
-    satellite-installer 
+    satellite-installer
       --scenario satellite
       --foreman-initial-organization "{{ satellite_organization }}"
       --foreman-initial-location "{{ satellite_location }}"
-      --foreman-admin-username "{{ satellite_username }}"
-      --foreman-admin-password "{{ satellite_password }}"
+      --foreman-initial-admin-username "{{ satellite_username }}"
+      --foreman-initial-admin-password "{{ satellite_password }}"
       --foreman-proxy-dns-managed=false
       --foreman-proxy-dhcp-managed=false


### PR DESCRIPTION
### What does this PR do?
Changes parameters passed to `satellite-installer` as 2 of them have been deprecated now.

### How should this be tested?
Follow role instructions

### Is there a relevant Issue open for this?
No

### People to notify
cc: @redhat-cop/infra-ansible
