### PR TITLE
Add a 'containerized' var to the ansible_tower inventory

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ldap/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ldap/README.md
@@ -15,6 +15,7 @@ The variables used to configure Ansible Tower LDAP are outlined in the table bel
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
 |ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
+|ansible_tower.containerized|Indicates whether this workload runs in a container|no|false|
 |ansible_tower.install.ldap.ca_cert|CA Certificate used for LDAP integration|no||
 |ansible_tower.install.ldap.uri|ldaps URL for LDAP server|yes||
 |ansible_tower.install.ldap.bind_dn|Bind DN used for LDAP integration|yes||
@@ -77,6 +78,7 @@ ansible_tower:
 
 ansible_tower:
   admin_password: 'admin'
+  containerized: false
   ldap:
     ca_cert: "{{ inventory_dir }}/../files/ca.crt"
     uri: "ldaps://idm.test.example.com:636"

--- a/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
+++ b/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
@@ -2,6 +2,10 @@
 
 - block: # become: True
 
+  - name: "Check if this is a containerized workload"
+    set_fact:
+      tower_containerized: "{{ ansible_tower.containerized | default(false) }}"
+
   - name: "Upload Cert CA to Ansible Tower (if applicable)"
     copy:
       src: "{{ ansible_tower.ldap.ca_cert }}"
@@ -9,6 +13,7 @@
     when:
     - ansible_tower.ldap.ca_cert is defined
     - ansible_tower.ldap.ca_cert|trim != ''
+    - tower_containerized is false
     notify:
     - restart-tower
     register: ca_uploaded
@@ -18,6 +23,7 @@
     when:
     - ca_uploaded is defined
     - ca_uploaded.changed
+    - tower_containerized is false
 
   - name: "Update Ansible Tower LDAP config"
     uri:
@@ -32,8 +38,10 @@
         Content-Type: "application/json"
         Accept: "application/json"
       validate_certs: no
+{% if tower_containerized is true %}
     notify:
     - restart-tower
+{% endif %}
 
 # This is only useful if the bind user is in the necessary LDAP group
   - name: "Force LDAP Sync"

--- a/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
+++ b/roles/ansible/tower/config-ansible-tower-ldap/tasks/ldap.yml
@@ -13,7 +13,7 @@
     when:
     - ansible_tower.ldap.ca_cert is defined
     - ansible_tower.ldap.ca_cert|trim != ''
-    - tower_containerized is false
+    - not tower_containerized
     notify:
     - restart-tower
     register: ca_uploaded
@@ -23,7 +23,7 @@
     when:
     - ca_uploaded is defined
     - ca_uploaded.changed
-    - tower_containerized is false
+    - not tower_containerized
 
   - name: "Update Ansible Tower LDAP config"
     uri:
@@ -38,10 +38,6 @@
         Content-Type: "application/json"
         Accept: "application/json"
       validate_certs: no
-{% if tower_containerized is true %}
-    notify:
-    - restart-tower
-{% endif %}
 
 # This is only useful if the bind user is in the necessary LDAP group
   - name: "Force LDAP Sync"

--- a/roles/ansible/tower/config-ansible-tower-ldap/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ldap/tests/inventory/group_vars/tower.yml
@@ -7,6 +7,7 @@ ansible_connection: local
 
 ansible_tower:
   admin_password: "admin01"
+  containerized: false
   ldap:
     ca_cert: "{{ inventory_dir }}/../files/ca.crt"
     uri: "ldaps://idm.test.example.com:636"

--- a/roles/ansible/tower/config-ansible-tower-ldap/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ldap/tests/inventory/group_vars/tower.yml
@@ -6,8 +6,9 @@ ansible_connection: local
 #       - please replace with valid values and files
 
 ansible_tower:
+  url: "https://mytower.example.com"
   admin_password: "admin01"
-  containerized: false
+  containerized: false 
   ldap:
     ca_cert: "{{ inventory_dir }}/../files/ca.crt"
     uri: "ldaps://idm.test.example.com:636"


### PR DESCRIPTION
### What does this PR do?
Introduces a `ansible_tower.containerized` variable in the inventory as some steps required by the non-OCP install aren't required by the OCP install. This will be the first PR in a series that will look to allow for a "combined" install role.

**Note:** Restart is no longer required after an LDAP configuration, so the handler was removed after the API call.

### How should this be tested?
Run the tests provided by the role

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
