### PR TITLE
Update tower license role

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-license/README.md
+++ b/roles/ansible/tower/config-ansible-tower-license/README.md
@@ -18,7 +18,7 @@ The variables used to configure Ansible Tower LDAP are outlined in the table bel
 |ansible_tower.admin_username|Admin username for the Ansible Tower install|yes||
 |ansible_tower.install.license_file|Path to valid Ansible Tower license content|yes||
 
-
+**Note:** You should ensure that the ansible_tower.url variable that is being used is not being redirected (i.e. redirected from http -> https, etc.). If there are concerns with how you're getting/setting this URL, you can use the `discover-url-redirect` role found in this repo.
 
 ## Example Inventory
 ```yaml

--- a/roles/ansible/tower/config-ansible-tower-license/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 
+default_ansible_tower_url: 'https://localhost'
+default_ansible_tower_admin_username: 'admin'

--- a/roles/ansible/tower/config-ansible-tower-license/tasks/license.yml
+++ b/roles/ansible/tower/config-ansible-tower-license/tasks/license.yml
@@ -7,17 +7,11 @@
     password: "{{ ansible_tower.admin_password }}"
     force_basic_auth: yes
     method: GET
-    validate_certs: "{{ validate_tower_certs | default(false) }}"
+    validate_certs: "{{ validate_tower_certs | default(true) }}"
   register: status_output 
   until: status_output.status == 200 
   retries: 6
   delay: 5
-
-- name: "Check Tower URL for redirect"
-  uri:
-    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
-    validate_certs: "{{ validate_tower_certs | default(false) }}"
-  register: tower_url
 
 - name: "Add Tower license"
   uri:
@@ -31,4 +25,4 @@
     headers:
       Content-Type: "application/json"
       Accept: "application/json"
-    validate_certs: "{{ validate_tower_certs | default(false) }}"
+    validate_certs: "{{ validate_tower_certs | default(true) }}"


### PR DESCRIPTION
### What does this PR do?
- Removes unnecessary tasks from the license role. 
- Add notes about ensuring you have an appropriate role and a note to use the discover-url-redirect route if you're unsure if there will be a redirect
- switch validate_certs to default to true

### How should this be tested?
Run the tests provided by the role

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
