### PR TITLE
Updating HAproxy config templates to be more flexible

### DIFF
--- a/roles/load-balancers/manage-haproxy/README.md
+++ b/roles/load-balancers/manage-haproxy/README.md
@@ -28,24 +28,17 @@ lb_config:
     lb_host_vip: '192.168.1.10'
     lb_host_port: 443
     lb_ssl_enabled: True [optional for port 443]
+    lb_mode: tcp [optional for port 443]
   - lb_name: my-secure-web-server-8443
     lb_host_vip: '192.168.1.10'
     lb_host_port: 8443
     lb_ssl_enabled: True
+    lb_mode: tcp
+  - lb_name: my-random-port-server-22623
+    lb_host_vip: '192.168.1.10'
+    lb_host_port: 22623
+    lb_mode: tcp
   lb_entries:
-  - lb_match_fqdn: master.env1.example.com
-    lb_match_port: 8443
-    lb_ssl_enabled: True
-    backends:
-    - host: master.env1.example.com
-      port: 8443
-  - lb_match_fqdn: .apps.env1.example.com
-    lb_match_port: 443
-    backends:
-    - host: router1.env1.example.com
-      port: 443
-    - host: router2.env1.example.com
-      port: 443
   - lb_match_fqdn: apps.env1.example.com
     lb_match_port: 80
     backends:
@@ -53,6 +46,33 @@ lb_config:
       port: 80
     - host: router2.env1.example.com
       port: 80
+  - lb_match_fqdn: .apps.env1.example.com
+    lb_match_port: 443
+    lb_ssl_enabled: True [optional for port 443]
+    lb_mode: tcp [optional for port 443]
+    backends:
+    - host: router1.env1.example.com
+      port: 443
+    - host: router2.env1.example.com
+      port: 443
+  - lb_match_fqdn: master.env1.example.com
+    lb_match_port: 8443
+    lb_ssl_enabled: True
+    lb_mode: tcp
+    backends:
+    - host: master.env1.example.com
+      port: 8443
+  - lb_match_port: 22623
+    lb_mode: tcp
+    lb_balance: first
+    backends:
+    - host: router1.env1.example.com
+      port: 22623
+      check: 'check'
+    - host: router2.env1.example.com
+      port: 22623
+      check: 'check'
+
 ```
 
 

--- a/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/generate-config.yml
@@ -30,7 +30,7 @@
   - name: 'Configure and Populate LB Frontends'
     template:
       src: "{{ lb_frontend_template | default('lb_frontend.j2') }}"
-      dest: '{{ haproxy_temp_dir }}/0002_lb_{{ fe.lb_name }}_{{ fe.lb_host_vip }}_{{ fe.lb_host_port }}.cfg'
+      dest: '{{ haproxy_temp_dir }}/0002_lb_{{ fe.lb_name }}_{{ fe.lb_host_vip | default("undef") }}_{{ fe.lb_host_port }}.cfg'
     loop_control:
       loop_var: fe
     loop: "{{ lb_config.frontends|flatten(levels=1) }}"

--- a/roles/load-balancers/manage-haproxy/templates/lb_backend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_backend.j2
@@ -1,6 +1,13 @@
 
 {% for entry in lb_config.lb_entries %}
 
+{% if ((entry.lb_mode is defined and entry.lb_mode == 'http') or
+       (entry.lb_mode is undefined and entry.lb_match_port|string == '80')) %}
+{% set lb_http_mode = True %}
+{% else %}
+{% set lb_http_mode = False %}
+{% endif %}
+
 {% if ((entry.lb_ssl_enabled is defined and entry.lb_ssl_enabled) or
        (entry.lb_ssl_enabled is undefined and entry.lb_match_port|string == '443')) %}
 {% set lb_ssl_enabled = True %}
@@ -8,13 +15,18 @@
 {% set lb_ssl_enabled = False %}
 {% endif %}
 
-{% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
 
-backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }}
-    balance roundrobin
-{% if lb_ssl_enabled %}
+{% set backend_name = (entry.name | default(entry.lb_match_fqdn) | default('default_backend')) | regex_replace('^\.', '') %}
+
+backend {{ backend_name }}-{{ entry.lb_match_port }}
+    balance {{ entry.lb_balance | default('roundrobin') }}
+{% if entry.lb_mode is defined %}
+    mode {{ entry.lb_mode }}
+{% elif lb_ssl_enabled %}
     mode tcp
-{% else %}
+{% endif %}
+
+{% if lb_http_mode %}
     option httpclose
     option forwardfor
     cookie JSESSIONID prefix
@@ -24,11 +36,16 @@ backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }}
 {% set lb_backend_host = backend.name | default(backend.host) %}
 {% set lb_backend_port = backend.port | default(entry.lb_match_port) %}
 
-{% if lb_ssl_enabled %}
-    server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} check
+{% if backend.check is defined %}
+{% set lb_backend_check = backend.check %}
+{% elif lb_http_mode %}
+{% set lb_backend_check = 'cookie A check' %}
 {% else %}
-    server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} cookie A check
+{% set lb_backend_check = 'check' %}
 {% endif %}
+
+    server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} {{ lb_backend_check }}
+
 {% endfor %}
 
 {% endfor %}

--- a/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
@@ -1,4 +1,11 @@
 
+{% if ((fe.lb_mode is defined and fe.lb_mode == 'http') or
+       (fe.lb_mode is undefined and fe.lb_host_port|string == '80')) %}
+{% set lb_http_mode = True %}
+{% else %}
+{% set lb_http_mode = False %}
+{% endif %}
+
 {% if ((fe.lb_ssl_enabled is defined and fe.lb_ssl_enabled) or
        (fe.lb_ssl_enabled is undefined and fe.lb_host_port|string == '443')) %}
 {% set lb_ssl_enabled = True %}
@@ -8,16 +15,21 @@
 
 frontend {{ fe.lb_name }}
     bind {{ fe.lb_host_vip | default('*') }}:{{ fe.lb_host_port }}
-{% if lb_ssl_enabled %}
+{% if fe.lb_mode is defined %}
+    mode {{ fe.lb_mode }}
+{% elif lb_ssl_enabled %}
     mode tcp
+{% endif %}
 
+{% if lb_ssl_enabled %}
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
 {% endif %}
 
 {% if lb_config.lb_entries is defined %}
 {% for entry in lb_config.lb_entries %}
-{% if entry.lb_match_port|string == fe.lb_host_port|string %}
+{% if entry.lb_match_fqdn is defined and
+      entry.lb_match_port|string == fe.lb_host_port|string %}
 {% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
 {% if lb_ssl_enabled %}
     acl {{ lb_match_fqdn }} req_ssl_sni -m end {{ entry.lb_match_fqdn }}
@@ -28,11 +40,13 @@ frontend {{ fe.lb_name }}
 {% endfor %}
 
 {% for entry in lb_config.lb_entries %}
-{% if entry.lb_match_port|string == fe.lb_host_port|string %}
+{% if entry.lb_match_fqdn is defined and
+      entry.lb_match_port|string == fe.lb_host_port|string %}
 {% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
     use_backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }} if {{ lb_match_fqdn }}
 {% endif %}
 {% endfor %}
-{% else %}
-    default_backend {{ fe.lb_name }}
 {% endif %}
+
+    default_backend default_backend-{{ fe.lb_host_port }}
+

--- a/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
@@ -43,10 +43,12 @@ frontend {{ fe.lb_name }}
 {% if entry.lb_match_fqdn is defined and
       entry.lb_match_port|string == fe.lb_host_port|string %}
 {% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
+{% set lb_default_needed = False %}
     use_backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }} if {{ lb_match_fqdn }}
 {% endif %}
 {% endfor %}
 {% endif %}
 
+{% if lb_default_needed is defined %}
     default_backend default_backend-{{ fe.lb_host_port }}
-
+{% endif %}


### PR DESCRIPTION
### What does this PR do?
Existing HAProxy configuration was too specific to a few use-cases. This PR updates the templates, etc. to allow for greater flexibility around how it can be used for other purposes than http/https traffic. 

### How should this be tested?
Create an inventory based on the examples in the READMEs, and run the playbooks to validate that HAproxy is correctly configured. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
