### PR TITLE
Fixing scope of true/false flags/checks + better whitespace control

### DIFF
--- a/roles/load-balancers/manage-haproxy/templates/lb_backend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_backend.j2
@@ -1,20 +1,21 @@
+{% set lb_ssl = namespace(enabled=False) -%}
+{% set lb_mode = namespace(http=False) -%}
 
 {% for entry in lb_config.lb_entries %}
 
 {% if ((entry.lb_mode is defined and entry.lb_mode == 'http') or
        (entry.lb_mode is undefined and entry.lb_match_port|string == '80')) %}
-{% set lb_http_mode = True %}
+{% set lb_mode.http = True %}
 {% else %}
-{% set lb_http_mode = False %}
-{% endif %}
+{% set lb_mode.http = False %}
+{% endif -%}
 
 {% if ((entry.lb_ssl_enabled is defined and entry.lb_ssl_enabled) or
        (entry.lb_ssl_enabled is undefined and entry.lb_match_port|string == '443')) %}
-{% set lb_ssl_enabled = True %}
+{% set lb_ssl.enabled = True %}
 {% else %}
-{% set lb_ssl_enabled = False %}
-{% endif %}
-
+{% set lb_ssl.enabled = False %}
+{% endif -%}
 
 {% set backend_name = (entry.name | default(entry.lb_match_fqdn) | default('default_backend')) | regex_replace('^\.', '') %}
 
@@ -22,30 +23,27 @@ backend {{ backend_name }}-{{ entry.lb_match_port }}
     balance {{ entry.lb_balance | default('roundrobin') }}
 {% if entry.lb_mode is defined %}
     mode {{ entry.lb_mode }}
-{% elif lb_ssl_enabled %}
+{% elif lb_ssl.enabled %}
     mode tcp
-{% endif %}
+{% endif -%}
 
-{% if lb_http_mode %}
+{% if lb_mode.http %}
     option httpclose
     option forwardfor
     cookie JSESSIONID prefix
-{% endif %}
+{% endif -%}
 
 {% for backend in entry.backends %}
-{% set lb_backend_host = backend.name | default(backend.host) %}
-{% set lb_backend_port = backend.port | default(entry.lb_match_port) %}
+{% set lb_backend_host = backend.name | default(backend.host) -%}
+{% set lb_backend_port = backend.port | default(entry.lb_match_port) -%}
 
 {% if backend.check is defined %}
 {% set lb_backend_check = backend.check %}
-{% elif lb_http_mode %}
+{% elif lb_mode.http %}
 {% set lb_backend_check = 'cookie A check' %}
 {% else %}
 {% set lb_backend_check = 'check' %}
 {% endif %}
-
     server {{ lb_backend_host }} {{ backend.host }}:{{ lb_backend_port }} {{ lb_backend_check }}
-
-{% endfor %}
-
-{% endfor %}
+{% endfor -%}
+{% endfor -%}

--- a/roles/load-balancers/manage-haproxy/templates/lb_common.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_common.j2
@@ -39,3 +39,4 @@ defaults
     timeout http-keep-alive 10s
     timeout check           10s
     maxconn                 3000
+

--- a/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
@@ -1,54 +1,51 @@
-
-{% if ((fe.lb_mode is defined and fe.lb_mode == 'http') or
-       (fe.lb_mode is undefined and fe.lb_host_port|string == '80')) %}
-{% set lb_http_mode = True %}
-{% else %}
-{% set lb_http_mode = False %}
-{% endif %}
+{% set lb_default = namespace(needed=True) -%}
+{% set lb_ssl = namespace(enabled=False) -%}
 
 {% if ((fe.lb_ssl_enabled is defined and fe.lb_ssl_enabled) or
        (fe.lb_ssl_enabled is undefined and fe.lb_host_port|string == '443')) %}
 {% set lb_ssl_enabled = True %}
-{% else %}
-{% set lb_ssl_enabled = False %}
-{% endif %}
+{% endif -%}
+
 
 frontend {{ fe.lb_name }}
     bind {{ fe.lb_host_vip | default('*') }}:{{ fe.lb_host_port }}
 {% if fe.lb_mode is defined %}
     mode {{ fe.lb_mode }}
-{% elif lb_ssl_enabled %}
+{% elif lb_ssl.enabled %}
     mode tcp
-{% endif %}
+{% endif -%}
 
-{% if lb_ssl_enabled %}
+{% if lb_ssl.enabled %}
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
-{% endif %}
+{% endif -%}
 
-{% if lb_config.lb_entries is defined %}
+{% if lb_config.lb_entries is defined -%}
+
 {% for entry in lb_config.lb_entries %}
 {% if entry.lb_match_fqdn is defined and
       entry.lb_match_port|string == fe.lb_host_port|string %}
 {% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
-{% if lb_ssl_enabled %}
+{% if lb_ssl.enabled %}
     acl {{ lb_match_fqdn }} req_ssl_sni -m end {{ entry.lb_match_fqdn }}
 {% else %}
     acl {{ lb_match_fqdn }} hdr_sub(host) -i {{ entry.lb_match_fqdn }}
-{% endif %}
-{% endif %}
-{% endfor %}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
 
 {% for entry in lb_config.lb_entries %}
 {% if entry.lb_match_fqdn is defined and
       entry.lb_match_port|string == fe.lb_host_port|string %}
 {% set lb_match_fqdn = (entry.name | default(entry.lb_match_fqdn)) | regex_replace('^\.', '') %}
-{% set lb_default_needed = False %}
     use_backend {{ lb_match_fqdn }}-{{ entry.lb_match_port }} if {{ lb_match_fqdn }}
-{% endif %}
-{% endfor %}
-{% endif %}
+{% set lb_default.needed = False %}
+{% endif -%}
+{% endfor -%}
 
-{% if lb_default_needed is defined %}
+{% endif -%}
+
+{% if lb_default.needed %}
     default_backend default_backend-{{ fe.lb_host_port }}
 {% endif %}
+

--- a/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
+++ b/roles/load-balancers/manage-haproxy/templates/lb_frontend.j2
@@ -3,7 +3,7 @@
 
 {% if ((fe.lb_ssl_enabled is defined and fe.lb_ssl_enabled) or
        (fe.lb_ssl_enabled is undefined and fe.lb_host_port|string == '443')) %}
-{% set lb_ssl_enabled = True %}
+{% set lb_ssl.enabled = True %}
 {% endif -%}
 
 


### PR DESCRIPTION
### What does this PR do?
The previous PR #412 introduced a bug whereas the `default` backend entry is missing in some cases. This is due to how jinja templates are processed and "global" variables not honored when used in loops - this changes their scope. The fix is to use a namespaced approach, which this PR now introduces. 

Also, this PR does clean-up around whitespace and removes many extra blank lines in the final configuration file. 

### How should this be tested?
Run through an inventory that generates a valid file - preferably testing most/all combinations. (see README for an example). 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible 
