### PR TITLE
CHANGED osp-provisioner.yml and moved part with dns_records to a corr…

### DIFF
--- a/inventory/idm-server/group_vars/idm-server.yml
+++ b/inventory/idm-server/group_vars/idm-server.yml
@@ -15,3 +15,16 @@ idm_domain: example.com
 idm_realm: EXAMPLE.COM
 idm_dm_password: my_dm_password
 idm_admin_password: my_admin_password
+
+dns_records:
+  server: "dns_server_ip"
+  reverse:
+    zone: "my_reverse_zone"
+    key_name: 'reverse_key_name'
+    key_secret: 'key_secret'
+    key_algorithm: 'hmac-sha256'
+  forward:
+    zone: "my_forward_zone"
+    key_name: 'forward_key_name'
+    key_secret: 'my_key_secret'
+    key_algorithm: 'hmac-sha256'

--- a/inventory/idm-server/group_vars/osp-provisioner.yml
+++ b/inventory/idm-server/group_vars/osp-provisioner.yml
@@ -109,15 +109,3 @@ osp_instances:
   - icmp-sec-group
   - idm-sec-group
 
-dns_records:
-  server: "dns_server_ip"
-  reverse:
-    zone: "my_reverse_zone"
-    key_name: 'reverse_key_name'
-    key_secret: 'key_secret'
-    key_algorithm: 'hmac-sha256'
-  forward:
-    zone: "my_forward_zone"
-    key_name: 'forward_key_name'
-    key_secret: 'my_key_secret'
-    key_algorithm: 'hmac-sha256'


### PR DESCRIPTION
…ect inventory for idm-server.yml

### What does this PR do?
Updated example inventory for IDM deployment. There were variables for dns_records in osp-provisioner.yml which caused failure of task "Set required ip address for forward dns" since it couldn't gather facts from a correct machine (osp-provisioner is localhost). Moved it to idm-server.yml which is the correct host group.

### How should this be tested?
Test it by running playbooks for provision-idm-server.

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.
n/a

### People to notify
cc: @redhat-cop/infra-ansible
