### PR TITLE
Adjusting the validation filter of 'credential.inputs'

### DIFF
--- a/roles/ansible/tower/manage-credentials/templates/credential.j2
+++ b/roles/ansible/tower/manage-credentials/templates/credential.j2
@@ -5,7 +5,7 @@
     "user": null,
     "team": null,
     "credential_type": {{ credential_type_id }},
-    {% if credential.inputs | length > 0 -%}
+    {% if credential.inputs is defined and credential.inputs | length > 0 -%}
     "inputs": {{ credential.inputs | to_json }}
     {% else -%}
     "inputs": {}


### PR DESCRIPTION
### What does this PR do?
This PR updates the filter defined in the file 'credential.j2' file to check the length if the 'credential.inputs' variable is defined. With the recent versions of Ansible, any playbook or role that depends on this check, gets interrupted with 'undefined variable' error.

### How should this be tested?
By provisioning Ansible Tower using our existing automation (playbooks/provision-ansible-tower/main.yml --tags="install"). This PR aims to successfully execute the necessary checks for credentials handling.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
