### PR TITLE
FIX failure with new ansible-tower-bundle folder strategy

### DIFF
--- a/roles/ansible/tower/config-ansible-tower/tasks/install.yml
+++ b/roles/ansible/tower/config-ansible-tower/tasks/install.yml
@@ -7,20 +7,20 @@
       name: "{{ ansible_tower_epel_download_url }}"
       state: present
 
+  - name: "Download & Unpack Ansible Tower installer"
+    unarchive:
+      src: "{{ ansible_tower_download_url }}"
+      dest: "."
+      list_files: true
+      remote_src: true
+      exclude: "inventory"
+    register: ansible_tower_download_fact
+
+  # The first file listed in the output of the unarchiving from downloading tower
+  # is the directory so set that as ansible_tower_dir
   - name: "Set installation dir fact"
     set_fact:
-      ansible_tower_dir: "{{ ansible_tower_download_url | basename | regex_replace('.tar.gz','') }}"
-
-  - name: "Check if installer dir exists"
-    stat:
-      path: "{{ ansible_tower_dir }}"
-    register: installer_dir
-
-  - name: "Download & Unpack Ansible Tower installer"
-    shell: curl {{ ansible_tower_download_url }} | tar xzf -
-    args:
-      warn: False
-    when: not installer_dir.stat.exists
+      ansible_tower_dir: "{{ ansible_tower_download_fact.files.0 }}"
 
   - name: "Set up the Ansible Tower inventory"
     template:


### PR DESCRIPTION
### What does this PR do?
The issue was that the ansible tower bundle has had all the el7 and el8 packages bundled into a single download and are named without this extension. This is something I came across in a previous customer and had to resolve. The fix I have included here involves using the unarchive module rather than a shell command and then taking the base dir which is created as the directory for the tower install.

### How should this be tested?
I have run a test with setup and setup bundles to download and retrieve the dir name. This has worked for new and old downloads (e.g. 3.6.3 and 3.4.0 and latest). The code block tested is the code I have added. (I know, manual testing... yuck!)

```yaml
---
- hosts: localhost
  connection: local
  vars:
    ansible_tower_download_url: https://releases.ansible.com/ansible-tower/setup-bundle/ansible-tower-setup-bundle-latest.el7.tar.gz  # or another version
  tasks:
    - name: "[Tower] Download and Extract Tower"
      unarchive:
        src: "{{ ansible_tower_download_url }}"
        dest: "."
        list_files: true
        remote_src: true
        exclude: "inventory"
      register: tower_download_extract

    - debug:
        var: tower_download_extract.files.0
```

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #410 

### People to notify
cc: @redhat-cop/infra-ansible
