### PR TITLE
Generate csr python3

### DIFF
--- a/roles/certs/generate-csr/library/generate_csr.py
+++ b/roles/certs/generate-csr/library/generate_csr.py
@@ -104,10 +104,10 @@ def generateCSR(cn, c, st, l, o, ou, email, sans):
     for san in sans:
         sans_list.append("DNS: {0}".format(san))
 
-    sans_list = ", ".join(sans_list)
+    sans_list = ", ".join(sans_list).encode()
 
     if sans_list:
-        x509_extensions.append(crypto.X509Extension("subjectAltName", False, sans_list))
+        x509_extensions.append(crypto.X509Extension("subjectAltName".encode(), False, sans_list))
 
     csr.add_extensions(x509_extensions)
 


### PR DESCRIPTION
### What does this PR do?
When using this role on Python 3 it will fail spectacularly
```
TASK [certs/generate-csr : Generate the private Key and a CSR] ******************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: initializer for ctype 'char *' mu
st be a bytes or list or tuple, not str                                                                                                      
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/pabraham/.ansible/tmp/
ansible-tmp-1588944968.8608756-362280-238365008753769/AnsiballZ_generate_csr.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/ho
me/pabraham/.ansible/tmp/ansible-tmp-1588944968.8608756-362280-238365008753769/AnsiballZ_generate_csr.py\", line 94, in _ansiballz_main\n    
invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/pabraham/.ansible/tmp/ansible-tmp-1588944968.8608756-362280-2383650087
53769/AnsiballZ_generate_csr.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.generate_csr', init_globals=None
, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.8/runpy.py\", line 206, in run_module\n    return _run_module_code(code, 
init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.8/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, i
nit_globals,\n  File \"/usr/lib64/python3.8/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_generate_cs
r_payload_e00307ea/ansible_generate_csr_payload.zip/ansible/modules/generate_csr.py\", line 158, in <module>\n  File \"/tmp/ansible_generate_
csr_payload_e00307ea/ansible_generate_csr_payload.zip/ansible/modules/generate_csr.py\", line 145, in main\n  File \"/tmp/ansible_generate_cs
r_payload_e00307ea/ansible_generate_csr_payload.zip/ansible/modules/generate_csr.py\", line 110, in generateCSR\n  File \"/usr/local/lib/pyth
on3.8/site-packages/OpenSSL/crypto.py\", line 762, in __init__\n    extension = _lib.X509V3_EXT_nconf(_ffi.NULL, ctx, type_name, value)\nType
Error: initializer for ctype 'char *' must be a bytes or list or tuple, not str\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/s
tderr for the exact error", "rc": 1}       
```

### How should this be tested?
Use the test that comes with the role on Python 3

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
