### PR TITLE
Prune support for Quay role

### DIFF
--- a/roles/scm/quay/README.md
+++ b/roles/scm/quay/README.md
@@ -22,6 +22,8 @@ Role Variables
 |:---------|:------------|:---------|:---------|
 |quay_host| Location of the Quay endpoint | no | `https://quay.io` |
 |quay_api_token| Quay API OAuth Token | yes | |
+|quay_validate_certs| Validate API Certificates | no | `true` |
+|quay_prune| Remove Quay org resources not defined in the inventory | `false` |
 |orgs| List of Quay organizations | yes | |
 
 A full list of supported variables can be found in the [test inventory](tests/inventory/group_vars/all.yml)

--- a/roles/scm/quay/defaults/main.yml
+++ b/roles/scm/quay/defaults/main.yml
@@ -7,4 +7,6 @@ quay_api_token: ""
 
 quay_validate_certs: true
 
+quay_prune: false
+
 orgs: []

--- a/roles/scm/quay/tasks/manage_organization.yml
+++ b/roles/scm/quay/tasks/manage_organization.yml
@@ -40,6 +40,24 @@
       Authorization: "{{ auth_header }}"
   when: quay_organization_exists.status == 200
 
+- name: Get Quay Organization
+  uri:
+    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
+    validate_certs: "{{ quay_validate_certs }}"
+    headers:
+      Authorization: "{{ auth_header }}"
+  register: current_quay_org
+
+- name: List Organization Robots
+  uri:
+    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots"
+    validate_certs: "{{ quay_validate_certs }}"
+    status_code:
+      - 200
+    headers:
+      Authorization: "{{ auth_header }}"
+  register: org_robots
+
 - name: Manage Robots
   include_tasks: manage_robot.yml
   loop: "{{ quay_organization.robots | default([]) }}"
@@ -52,8 +70,66 @@
   loop_control:
     loop_var: quay_team
 
+- name: List Repositories
+  uri:
+    url: "{{ quay_api_base }}/repository?namespace={{ quay_organization.name }}"
+    validate_certs: "{{ quay_validate_certs }}"
+    body_format: json
+    status_code:
+      - 200
+      - 404
+    headers:
+      Authorization: "{{ auth_header }}"
+  register: org_repositories
+
+
 - name: Manage Repositories
   include_tasks: manage_repository.yml
   loop: "{{ quay_organization.repos | default([]) }}"
   loop_control:
     loop_var: quay_repository
+
+- name: Prune Organization
+  block:
+    - name: Delete Extra Robot Accounts
+      uri:
+        url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots/{{ item.name.split('+')[1] }}"
+        method: DELETE
+        validate_certs: "{{ quay_validate_certs }}"
+        status_code:
+          - 204
+        headers:
+          Authorization: "{{ auth_header }}"
+      loop: "{{ org_robots.json.robots }}"
+      when: "item.name.split('+')[1] not in quay_organization.robots |  map(attribute='name') | list"
+
+    - name: "Warn on Max Repositories Found"
+      debug:
+        msg: "Warning: Repositories Found: {{ org_repositories.json.repositories | length }}. Purging Only Supported on Organizations with <= 100 Repositories"
+      when: org_repositories.json.repositories | length > 100
+
+    - name: Delete Extra Repositories
+      uri:
+        url: "{{ quay_api_base }}/repository/{{ quay_organization.name }}/{{ item.name }}"
+        method: DELETE
+        validate_certs: "{{ quay_validate_certs }}"
+        status_code:
+          - 204
+        headers:
+          Authorization: "{{ auth_header }}"
+      loop: "{{ org_repositories.json.repositories }}"
+      when: "item.name not in quay_organization.repos |  map(attribute='name') | list"
+
+    - name: Delete Extra Teams
+      uri:
+        url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ item.key }}"
+        method: DELETE
+        validate_certs: "{{ quay_validate_certs }}"
+        status_code:
+          - 204
+        headers:
+          Authorization: "{{ auth_header }}"
+      loop: "{{ current_quay_org.json.teams | dict2items }}"
+      when: "item.key not in quay_organization.teams |  map(attribute='name') | list"
+
+  when: quay_prune|bool

--- a/roles/scm/quay/tasks/manage_repository.yml
+++ b/roles/scm/quay/tasks/manage_repository.yml
@@ -1,17 +1,8 @@
 ---
 
-- name: Check if repository exists
-  uri:
-    url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}"
-    validate_certs: "{{ quay_validate_certs }}"
-    body_format: json
-    status_code:
-      - 200
-      - 404
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: quay_repository_exists
-
+- name: Set if repository currently exists
+  set_fact:
+    org_repository_exists: "{{ quay_repository.name in org_repositories.json.repositories | map(attribute='name') | list }}"
 
 - name: Create Quay Repository
   uri:
@@ -28,7 +19,7 @@
     status_code: 201
     headers:
       Authorization: "{{ auth_header }}"
-  when: quay_repository_exists.status == 404
+  when: not org_repository_exists|bool
 
 - name: Update Quay Repository
   uri:
@@ -45,7 +36,7 @@
     status_code: 200
     headers:
       Authorization: "{{ auth_header }}"
-  when: quay_repository_exists.status == 200
+  when: org_repository_exists|bool
 
 - name: Manage Permissions
   uri:
@@ -60,3 +51,50 @@
       Authorization: "{{ auth_header }}"
   loop: "{{ quay_repository.permissions | default([]) }}"
 
+- name: Delete Extra Permissions
+  block:
+    - name: List Repository Team Permissions
+      uri:
+        url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/team/"
+        validate_certs: "{{ quay_validate_certs }}"
+        body_format: json
+        status_code:
+          - 200
+          - 404
+        headers:
+          Authorization: "{{ auth_header }}"
+      register: org_repositories_permissions_teams
+    - name: List Repository User Permissions
+      uri:
+        url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/user/"
+        validate_certs: "{{ quay_validate_certs }}"
+        body_format: json
+        status_code:
+          - 200
+          - 404
+        headers:
+          Authorization: "{{ auth_header }}"
+      register: org_repositories_permissions_users
+    - name: Delete Extra Permissions Team
+      uri:
+        url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/team/{{ item.key }}"
+        method: DELETE
+        validate_certs: "{{ quay_validate_certs }}"
+        status_code:
+        - 204
+        headers:
+          Authorization: "{{ auth_header }}"
+      loop: "{{ org_repositories_permissions_teams.json.permissions | dict2items }}"
+      when: (quay_repository.permissions | default([])) | selectattr('name', 'equalto', item.key) | list |  length == 0
+    - name: Delete Extra Permissions User
+      uri:
+        url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/user/{{ item.value.name }}"
+        method: DELETE
+        validate_certs: "{{ quay_validate_certs }}"
+        status_code:
+        - 204
+        headers:
+          Authorization: "{{ auth_header }}"
+      loop: "{{ org_repositories_permissions_users.json.permissions | dict2items }}"
+      when: (quay_repository.permissions | default([])) | selectattr('name', 'equalto', item.value.name.split('+')[1] if item.value.is_robot else item.value.name) | list |  length == 0
+  when: quay_prune|bool

--- a/roles/scm/quay/tasks/manage_robot.yml
+++ b/roles/scm/quay/tasks/manage_robot.yml
@@ -1,16 +1,5 @@
 ---
 
-- name: Check if Robot exists
-  uri:
-    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots/{{ quay_robot.name }}"
-    validate_certs: "{{ quay_validate_certs }}"
-    status_code:
-      - 200
-      - 400
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: quay_robot_exists
-
 - name: Create/Update Quay Robot
   uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots/{{ quay_robot.name }}"
@@ -23,4 +12,4 @@
       - 201
     headers:
       Authorization: "{{ auth_header }}"
-  when: quay_robot_exists.status == 400
+  when: quay_organization.name + '+' + quay_robot.name not in org_robots.json.robots |  map(attribute='name') | list

--- a/roles/scm/quay/tasks/manage_team.yml
+++ b/roles/scm/quay/tasks/manage_team.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Crerate/Update Quay Team
+- name: Create/Update Quay Team
   uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}"
     method: PUT
@@ -15,8 +15,33 @@
     headers:
       Authorization: "{{ auth_header }}"
 
+- name: Get Team Members
+  uri:
+    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members"
+    validate_certs: "{{ quay_validate_certs }}"
+    status_code:
+      - 200
+    headers:
+      Authorization: "{{ auth_header }}"
+  register: quay_team_members
+
 - name: Manage Team Members
   include_tasks: manage_team_members.yml
   loop: "{{ quay_team.members | default([]) }}"
   loop_control:
     loop_var: team_member
+
+- name: Delete Extra Team Members
+  block:
+    - name: Delete Team Member
+      uri:
+        url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members/{{ quay_organization.name + '+' + item.name if 'type' in item and item.type == 'robot' else item.name }}"
+        method: DELETE
+        validate_certs: "{{ quay_validate_certs }}"
+        status_code:
+        - 204
+        headers:
+          Authorization: "{{ auth_header }}"
+      loop: "{{ quay_team_members.json.members }}"
+      when: (quay_team.members | default([])) | selectattr('name', 'equalto', item.name.split('+')[1] if item.is_robot else item.name) | list |  length == 0
+  when: quay_prune|bool

--- a/roles/scm/quay/tasks/manage_team_members.yml
+++ b/roles/scm/quay/tasks/manage_team_members.yml
@@ -1,15 +1,5 @@
 ---
 
-- name: Get Team Members
-  uri:
-    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members"
-    validate_certs: "{{ quay_validate_certs }}"
-    status_code:
-      - 200
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: quay_team_members
-
 - name: Add Team Members
   uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members/{{ quay_organization.name + '+' + team_member.name if 'type' in team_member and team_member.type == 'robot' else team_member.name }}"


### PR DESCRIPTION
### What does this PR do?
Updates Quay role to support pruning

### How should this be tested?
Follow readme on how to define an inventory. `tests` folder has a sample inventory. After initial bootstrapping. Define a new repository, team, etc manually. Rerun automation by passing `quay_prune` inventory variable. Manual configuration should be removed

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
No

### People to notify
cc: @redhat-cop/infra-ansible 
