### PR TITLE
Adding an index to the generated view files to ensure order

### DIFF
--- a/roles/dns/manage-dns-zones-bind/tasks/process-views.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/process-views.yml
@@ -17,6 +17,7 @@
     - "{{ dns_data.views }}"
   loop_control:
     loop_var: "view"
+    index_var: "view_idx"
 
 - name: Assemble the final view configuration
   assemble:

--- a/roles/dns/manage-dns-zones-bind/tasks/process-zones.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/process-zones.yml
@@ -46,7 +46,7 @@
   - name: Assemble the complete view file
     assemble:
       src: "{{ dns_zone_temp_config_dir }}/{{ view.name }}"
-      dest: "{{ dns_zone_temp_config_dir }}/view/{{ view.name }}.cfg"
+      dest: "{{ dns_zone_temp_config_dir }}/view/{{ view_idx }}-{{ view.name }}.cfg"
   when:
     - processed_zones|bool == True
     - view.state|default('present') == 'present'


### PR DESCRIPTION
### What does this PR do?
The order of the DNS views were previously written in alphabetical order instead of the order specified in the inventory list. This PR fixes this issue by using an index on the temporary files created. In that way the `assemble` module will assemble the final file in the same order as what is specified in the inventory list. 

### How should this be tested?
Run with an inventory that has a list of views and observe that the order the views are listed in the file on the DNS server (`/etc/named/named.conf.view`) is the same order as in the inventory. Then change the order of the views around and re-run automation - observe that the file is changed accordingly. 

### Is there a relevant Issue open for this?
resolves #468 

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @ostefek99 
