### PR TITLE
Fixing issues with corrupted zone files during bind/named reconfiguration

### DIFF
--- a/roles/dns/manage-dns-zones-bind/defaults/main.yml
+++ b/roles/dns/manage-dns-zones-bind/defaults/main.yml
@@ -7,6 +7,9 @@ default_ttl: 300
 bind_user: named
 bind_group: named
 
+runtime_config_location: "/var/named"
+zone_files_location: "{{ runtime_config_location }}/static"
+
 default_recursion: false
 dnssec_keygen_size: 256
 dnssec_keygen_algorithm: HMAC-SHA256

--- a/roles/dns/manage-dns-zones-bind/tasks/generate_keys.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/generate_keys.yml
@@ -6,6 +6,8 @@
   with_subelements:
     - "{{ dns_data.views }}"
     - zones
+  when:
+   - item.1.type is undefined or (item.1.type is defined and item.1.type != "forward")
 
 - name: Initialize dictionary for nsupdate keys
   set_fact:
@@ -13,7 +15,7 @@
 
 - name: Get existing key files
   find:
-    paths: /var/named
+    paths: "{{ runtime_config_location }}"
     patterns: '*.key'
   register: key_files
 
@@ -41,7 +43,7 @@
 
 - name: Ensure target directory exists for archived files
   file:
-    path: "/var/named/key-archive"
+    path: "{{ runtime_config_location }}/key-archive"
     state: directory
 
 - name: Generate keys for nsupdate
@@ -51,7 +53,7 @@
       -b {{ dnssec_keygen_size }}
       -n USER
       -r /dev/urandom
-      -K /var/named/key-archive {{ item.name }}
+      -K {{ runtime_config_location }}/key-archive {{ item.name }}
   with_items:
     - "{{ dns_views }}"
   when:
@@ -60,7 +62,7 @@
 
 - block:
   - name: Gather keys for nsupdate
-    shell: "grep Key: /var/named/key-archive/{{ item.stdout }}.private | cut -d ' ' -f 2"
+    shell: "grep Key: {{ runtime_config_location }}/key-archive/{{ item.stdout }}.private | cut -d ' ' -f 2"
     register: nsupdate_keys_captured
     with_items:
       - "{{ dnssec_keygen_command_output.results }}"

--- a/roles/dns/manage-dns-zones-bind/tasks/keys.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/keys.yml
@@ -18,7 +18,7 @@
 - name: Setup key files for nsupdate
   template:
     src: tsig-key.j2
-    dest: /var/named/{{ item.key }}.key
+    dest: "{{ runtime_config_location }}/{{ item.key }}.key"
     owner: "{{ bind_user }}"
     group: "{{ bind_group }}"
     mode: 0660

--- a/roles/dns/manage-dns-zones-bind/tasks/prereq.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/prereq.yml
@@ -20,3 +20,8 @@
 - name: Store away the temporary configuration files directory name
   set_fact:
     dns_zone_temp_config_dir: "{{ dns_zone_tempdir.path }}"
+
+- name: Obtain current state of services
+  service_facts:
+  register: service_facts
+

--- a/roles/dns/manage-dns-zones-bind/tasks/process-one-zone.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/process-one-zone.yml
@@ -10,7 +10,7 @@
     state: absent
   ignore_errors: True
   with_items:
-    - "/var/named/static/{{ view.name + '-' + zone.dns_domain }}.db"
+    - "{{ zone_files_location }}/{{ view.name + '-' + zone.dns_domain }}.db"
   when:
     - zone_state == 'absent'
 
@@ -23,9 +23,12 @@
       dest: "/var/named/static/{{ view.name + '-' + zone.dns_domain }}.db"
       owner: "{{ bind_user }}"
       group: "{{ bind_group }}"
+      force: False
       mode: 0660
     notify: restart named
-
+    when:
+      - zone.type|default('master') != 'forward'
+    
   - name: Prepare the zone config content
     vars:
       zone_type: "{{ zone.type | default('master') }}"
@@ -38,6 +41,7 @@
       owner: "{{ bind_user }}"
       group: "{{ bind_group }}"
       mode: 0660
+    notify: restart named
 
   - name: "Set flag that a zone was processed"
     set_fact:

--- a/roles/dns/manage-dns-zones-bind/tasks/process-views.yml
+++ b/roles/dns/manage-dns-zones-bind/tasks/process-views.yml
@@ -12,6 +12,13 @@
   run_once: true
   delegate_to: "{{ ansible_play_hosts | first }}"
 
+- name: Flush any cache data and reload before making zone changes
+  block:
+    - command: /sbin/rndc flush
+    - command: /sbin/rndc reload
+  when:
+  - service_facts.ansible_facts.services['named.service'].state == "running"
+
 - include_tasks: process-zones.yml
   with_items:
     - "{{ dns_data.views }}"

--- a/roles/dns/manage-dns-zones-bind/templates/list-tsig-keys.j2
+++ b/roles/dns/manage-dns-zones-bind/templates/list-tsig-keys.j2
@@ -1,7 +1,8 @@
 {% for view in named_views %}
 {% for zone in view.zones %}
 {% if ((view.state is undefined or (view.state is defined and view.state != "absent")) and
-       (zone.state is undefined or (zone.state is defined and zone.state != "absent"))) %}
+       (zone.state is undefined or (zone.state is defined and zone.state != "absent")) and
+       (zone.type is undefined or (zone.type is defined and zone.type != "forward"))) %}
 include "{{ view.name }}-{{ zone.dns_domain }}.key";
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
### What does this PR do?
This changes the zone/view configuration role to avoid corrupting the zone files when a change is made to the DNS view/zone list. A couple of preventative changes made:

- Only touch the zone file if it doesn't already exists
- Any cached data is now flushed to disk before the configuration happens

Note that with the item 1 above, it will now **not** allow for any updates to the zone file post initial creation. This should not be a problem as-is since no data is managed by this tooling in the zone file beyond the initial creation. 

Another couple of "enhancements" as part of this PR:
- Using variables for file locations on disk
- Preventing zone files and tsig keys from being created for "forward-only" zones

### How should this be tested?

1. Run automation to set up DNS server
2. Run automation to create zone files
3. Run automation to populate a few DNS records 
4. Add additional zones/views to the inventory and re-run the automation to have these created
5. Observe that nsupdate/automation can still update DNS records in pre-existing zones

### Is there a relevant Issue open for this?
resolves #450 

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @ostefek99 
