### PR TITLE
Add support for HTTPS/SSL on Red Hat SSO

### DIFF
--- a/inventory/rh-sso/group_vars/all.yml
+++ b/inventory/rh-sso/group_vars/all.yml
@@ -16,6 +16,6 @@ rhsm_password: "{{ lookup('env', 'RHSM_PASSWD' )}}"
 rhsm_pool: "{{ lookup('env', 'RHSM_POOL' )}}"
 
 # Red Hat Single Sign-On Instance
-rh_sso_host: "192.168.16.3"
-rh_sso_port: 8443
+#rh_sso_host: rh-sso.example.com
+#rh_sso_port: 4444
 ssl_cert_validation: "no"

--- a/inventory/rh-sso/group_vars/all.yml
+++ b/inventory/rh-sso/group_vars/all.yml
@@ -18,3 +18,4 @@ rhsm_pool: "{{ lookup('env', 'RHSM_POOL' )}}"
 # Red Hat Single Sign-On Instance
 rh_sso_host: "192.168.16.3"
 rh_sso_port: 8443
+ssl_cert_validation: "no"

--- a/inventory/rh-sso/group_vars/all.yml
+++ b/inventory/rh-sso/group_vars/all.yml
@@ -17,4 +17,4 @@ rhsm_pool: "{{ lookup('env', 'RHSM_POOL' )}}"
 
 # Red Hat Single Sign-On Instance
 rh_sso_host: "192.168.16.3"
-rh_sso_port: 8080
+rh_sso_port: 8443

--- a/inventory/rh-sso/group_vars/all.yml
+++ b/inventory/rh-sso/group_vars/all.yml
@@ -17,5 +17,6 @@ rhsm_pool: "{{ lookup('env', 'RHSM_POOL' )}}"
 
 # Red Hat Single Sign-On Instance
 #rh_sso_host: rh-sso.example.com
+#rh_sso_protocol: http
 #rh_sso_port: 4444
-ssl_cert_validation: "no"
+rh_sso_ssl_cert_validation: "no"

--- a/inventory/rh-sso/group_vars/osp-provisioner.yml
+++ b/inventory/rh-sso/group_vars/osp-provisioner.yml
@@ -40,11 +40,6 @@ osp_security_groups:
     direction: ingress
     remote_ip_prefix: 0.0.0.0/0
   - protocol: tcp
-    port_range_min: 8080
-    port_range_max: 8080
-    direction: ingress
-    remote_ip_prefix: 0.0.0.0/0
-  - protocol: tcp
     port_range_min: 9990
     port_range_max: 9990
     direction: ingress

--- a/inventory/rh-sso/group_vars/osp-provisioner.yml
+++ b/inventory/rh-sso/group_vars/osp-provisioner.yml
@@ -35,6 +35,11 @@ osp_security_groups:
   description: "My sso Sec Group"
   rules:
   - protocol: tcp
+    port_range_min: 8443
+    port_range_max: 8443
+    direction: ingress
+    remote_ip_prefix: 0.0.0.0/0
+  - protocol: tcp
     port_range_min: 8080
     port_range_max: 8080
     direction: ingress

--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -8,7 +8,7 @@ list_of_packages_to_install:
 
 sso_admin_user: admin
 sso_admin_pass: mypa55ss
-sso_keystore_name: atrodrig
+sso_keystore_name: default
 sso_keystore_pass: changeit
 sso_keystore_path: "/etc/security/keystore.jks"
 

--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -8,6 +8,7 @@ list_of_packages_to_install:
 
 sso_admin_user: admin
 sso_admin_pass: mypa55ss
+sso_keystore_pass: changeit
 
 realms:
   - name: my-awesome-realm

--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -6,6 +6,7 @@ ansible_become: True
 list_of_packages_to_install:
   - "@rh-sso7"
 
+sso_protocol: https
 sso_admin_user: admin
 sso_admin_pass: mypa55ss
 sso_keystore_name: default

--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -8,21 +8,23 @@ list_of_packages_to_install:
 
 sso_admin_user: admin
 sso_admin_pass: mypa55ss
+sso_keystore_name: atrodrig
 sso_keystore_pass: changeit
+sso_keystore_path: "/etc/security/keystore.jks"
 
 realms:
-  - name: my-awesome-realm
-    id: my-awesome-realm
-    displayName: "My Awesome Realm"
-    enabled: true
-    sslRequired: "external"
-    registrationAllowed: true
-    emailLogin: true
-    dupsAllowed: false
-    resetPwd: false
-    editUname: false
-    bruteForceProtected: true
-  - name: a-simpler-realm
-    id: simple-realm
-    displayName: "Simple Times"
-    enabled: false
+  - realm_name: my-awesome-realm
+    realm_id: my-awesome-realm
+    realm_displayName: "My Awesome Realm"
+    realm_enabled: true
+    realm_sslRequired: "external"
+    realm_registrationAllowed: true
+    realm_emailLogin: true
+    realm_dupsAllowed: false
+    realm_resetPwd: false
+    realm_editUname: false
+    realm_bruteForceProtected: true
+  - realm_name: a-simpler-realm
+    realm_id: simple-realm
+    realm_displayName: "Simple Times"
+    realm_enabled: false

--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -6,12 +6,12 @@ ansible_become: True
 list_of_packages_to_install:
   - "@rh-sso7"
 
-sso_protocol: https
 sso_admin_user: admin
 sso_admin_pass: mypa55ss
-sso_keystore_name: default
-sso_keystore_pass: changeit
-sso_keystore_path: "/etc/security/keystore.jks"
+rh_sso_protocol: https
+rh_sso_keystore_name: default
+rh_sso_keystore_pass: changeit
+rh_sso_keystore_path: "/etc/security/keystore.jks"
 
 realms:
   - realm_name: my-awesome-realm

--- a/inventory/rh-sso/hosts
+++ b/inventory/rh-sso/hosts
@@ -12,3 +12,6 @@ rh-sso-hosts
 
 [identity-hosts:children]
 rh-sso-hosts
+
+[cert-host:children]
+rh-sso-hosts

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-rh_sso_host: "{{ ansible_facts.default_ipv4.address }}"
-rh_sso_port: 8080
+rh_sso_host: "127.0.0.1"
+rh_sso_port: 8443
 rh_sso_port_list:
   - 8443/tcp
   - 8080/tcp

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -3,5 +3,6 @@
 rh_sso_host: "{{ ansible_facts.default_ipv4.address }}"
 rh_sso_port: 8080
 rh_sso_port_list:
+  - 8443/tcp
   - 8080/tcp
   - 9990/tcp

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -1,7 +1,12 @@
 ---
 
 rh_sso_host: "{{ ansible_default_ipv4.address }}"
+rh_sso_protocol: https
 rh_sso_port: 8443
 rh_sso_port_list:
   - 8443/tcp
   - 9990/tcp
+
+rh_sso_keystore_name: default
+rh_sso_keystore_pass: changeit
+rh_sso_keystore_path: "/etc/security/keystore.jks"

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -4,5 +4,4 @@ rh_sso_host: "127.0.0.1"
 rh_sso_port: 8443
 rh_sso_port_list:
   - 8443/tcp
-  - 8080/tcp
   - 9990/tcp

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-rh_sso_host: "127.0.0.1"
+rh_sso_host: "{{ ansible_default_ipv4.address }}"
 rh_sso_port: 8443
 rh_sso_port_list:
   - 8443/tcp

--- a/roles/config-rh-sso/tasks/configure-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/configure-rh-sso.yml
@@ -6,7 +6,7 @@
 
 - name: "Requesting Access Token"
   uri:
-    url: "http://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
+    url: "https://127.0.0.1:8443/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body_format: form-urlencoded
     body:
@@ -18,7 +18,7 @@
 
 - name: "Create Realm for service Red Hat Single Sign-On"
   uri:
-    url: "http://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
+    url: "https://127.0.0.1:8443/auth/admin/realms"
     method: POST
     body: "{{ realm_json }}"
     body_format: json

--- a/roles/config-rh-sso/tasks/create_realm.yml
+++ b/roles/config-rh-sso/tasks/create_realm.yml
@@ -6,7 +6,7 @@
 
 - name: "Requesting Access Token"
   uri:
-    url: "{{ sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
+    url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body_format: form-urlencoded
     body:
@@ -14,17 +14,17 @@
       password: "{{ sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
   register: rh_sso_token
 
 - name: "Create Realm for service Red Hat Single Sign-On"
   uri:
-    url: "{{ sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
+    url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
     method: POST
     body: "{{ realm_json }}"
     body_format: json
     status_code: 201, 409
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
   register: rh_sso_realm_create

--- a/roles/config-rh-sso/tasks/create_realm.yml
+++ b/roles/config-rh-sso/tasks/create_realm.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: "Retrieve template for realm: {{ realm.name }}"
+- name: "Retrieve template for realm: {{ realm_data.realm_name }}"
   set_fact:
     realm_json: "{{ lookup('template', 'realm.json.j2') | to_json }}"
 
 - name: "Requesting Access Token"
   uri:
-    url: "https://127.0.0.1:8443/auth/realms/master/protocol/openid-connect/token"
+    url: "https://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body_format: form-urlencoded
     body:
@@ -14,15 +14,17 @@
       password: "{{ sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
+    validate_certs: "{{ ssl_cert_validation | default(yes) }}"
   register: rh_sso_token
 
 - name: "Create Realm for service Red Hat Single Sign-On"
   uri:
-    url: "https://127.0.0.1:8443/auth/admin/realms"
+    url: "https://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
     method: POST
     body: "{{ realm_json }}"
     body_format: json
     status_code: 201, 409
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
+    validate_certs: "{{ ssl_cert_validation | default(yes) }}"
   register: rh_sso_realm_create

--- a/roles/config-rh-sso/tasks/create_realm.yml
+++ b/roles/config-rh-sso/tasks/create_realm.yml
@@ -6,7 +6,7 @@
 
 - name: "Requesting Access Token"
   uri:
-    url: "https://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
+    url: "{{ sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body_format: form-urlencoded
     body:
@@ -19,7 +19,7 @@
 
 - name: "Create Realm for service Red Hat Single Sign-On"
   uri:
-    url: "https://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
+    url: "{{ sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
     method: POST
     body: "{{ realm_json }}"
     body_format: json

--- a/roles/config-rh-sso/tasks/main.yml
+++ b/roles/config-rh-sso/tasks/main.yml
@@ -3,7 +3,8 @@
 
 - import_tasks: 'prereq.yml'
 - import_tasks: 'setup-rh-sso.yml'
-- include_tasks: 'configure-rh-sso.yml'
+- include_tasks: 'create_realm.yml'
   loop: "{{ realms }}"
   loop_control:
-    loop_var: realm
+    loop_var: realm_data
+  tags: create-realm

--- a/roles/config-rh-sso/tasks/setup-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso.yml
@@ -28,11 +28,11 @@
 
 - name: 'Create a keystore to store SSL certificates'
   java_keystore:
-    name: "{{ sso_keystore_name }}"
+    name: "{{ rh_sso_keystore_name }}"
     certificate: "{{lookup('file', '../path/to/file.cer') }}"
     private_key: "{{lookup('file', '../path/to/file.key') }}"
-    password: "{{ sso_keystore_pass }}"
-    dest: "{{ sso_keystore_path }}"
+    password: "{{ rh_sso_keystore_pass }}"
+    dest: "{{ rh_sso_keystore_path }}"
 
 - name: 'Add a new SSL based security-realm'
   shell: >
@@ -48,7 +48,7 @@
 - name: 'Configure security-realm to use the keystore'
   shell: >
     "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ sso_keystore_path }}", keystore-password="{{ sso_keystore_pass }}")'
+    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ rh_sso_keystore_path }}", keystore-password="{{ rh_sso_keystore_pass }}")'
   args:
     executable: "/bin/bash"
   register: process_undertowrealm

--- a/roles/config-rh-sso/tasks/setup-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso.yml
@@ -3,11 +3,47 @@
   import_role:
     name: ../roles/config-packages
 
-- name: 'Update SSO bind addresses'
-  replace:
-    path: /etc/opt/rh/rh-sso7/keycloak/standalone/standalone.xml
-    regexp: '127.0.0.1'
-    replace: '0.0.0.0'
+- name: 'Update Red Hat SSO management/public interface IP address'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/interface=management:write-attribute(name=inet-address,value="${jboss.bind.address:0.0.0.0}")'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/interface=public:write-attribute(name=inet-address,value="${jboss.bind.address:0.0.0.0}")'
+  args:
+    executable: "/bin/bash"
+
+- name: 'Create a keystore to store SSL certificates'
+  java_keystore:
+    name: example
+    certificate: "{{lookup('file', 'path/to/the/file.cer') }}"
+    private_key: "{{lookup('file', 'path/to/the/file.key') }}"
+    password: "{{ sso_keystore_pass }}"
+    dest: /etc/security/keystore.jks
+
+- name: 'Add a new SSL based security-realm'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/core-service=management/security-realm=UndertowRealm:add()'
+  args:
+    executable: "/bin/bash"
+  ignore_errors: yes
+
+- name: 'Configure security-realm to use the keystore'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path=/etc/security/keystore.jks, keystore-password="{{ sso_keystore_pass }}")'
+  args:
+    executable: "/bin/bash"
+  ignore_errors: yes
+
+- name: 'Point the https-listener to the security-realm'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm, value=UndertowRealm)'
+  args:
+    executable: "/bin/bash"
+  ignore_errors: yes
 
 - name: 'Add a default SSO administration user'
   shell: >
@@ -16,6 +52,7 @@
     --password "{{ sso_admin_pass }}"
   args:
     executable: "/bin/bash"
+  ignore_errors: yes
 
 - name: 'Start Red Hat SSO in Standalone mode'
   service:
@@ -24,4 +61,4 @@
 
 - name: 'Waiting for SSO service to load'
   pause:
-    seconds: '30'
+    seconds: '10'

--- a/roles/config-rh-sso/tasks/setup-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso.yml
@@ -3,10 +3,23 @@
   import_role:
     name: ../roles/config-packages
 
-- name: 'Update Red Hat SSO management/public interface IP address'
+- name: 'Start Red Hat SSO in Standalone mode'
+  service:
+    name: rh-sso7
+    state: restarted
+
+- name: 'Waiting for SSO service to load'
+  pause:
+    seconds: '30'
+
+- name: 'Update Red Hat SSO management interface IP address'
   shell: >
     "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/interface=management:write-attribute(name=inet-address,value="${jboss.bind.address:0.0.0.0}")'
+    --command='/interface=management:write-attribute(name=inet-address,value="${jboss.bind.address.management:0.0.0.0}")'
+  args:
+    executable: "/bin/bash"
+
+- name: 'Update Red hat SSO public interface IP address'
   shell: >
     "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
     --command='/interface=public:write-attribute(name=inet-address,value="${jboss.bind.address:0.0.0.0}")'
@@ -16,8 +29,8 @@
 - name: 'Create a keystore to store SSL certificates'
   java_keystore:
     name: "{{ sso_keystore_name }}"
-    certificate: "{{lookup('file', 'path/to/the/file.cer') }}"
-    private_key: "{{lookup('file', 'path/to/the/file.key') }}"
+    certificate: "{{lookup('file', '../path/to/file.cer') }}"
+    private_key: "{{lookup('file', '../path/to/file.key') }}"
     password: "{{ sso_keystore_pass }}"
     dest: "{{ sso_keystore_path }}"
 
@@ -60,7 +73,7 @@
   args:
     executable: "/bin/bash"
 
-- name: 'Start Red Hat SSO in Standalone mode'
+- name: 'Restart Red Hat SSO service to apply changes'
   service:
     name: rh-sso7
     state: restarted

--- a/roles/config-rh-sso/tasks/setup-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso.yml
@@ -15,11 +15,11 @@
 
 - name: 'Create a keystore to store SSL certificates'
   java_keystore:
-    name: example
+    name: "{{ sso_keystore_name }}"
     certificate: "{{lookup('file', 'path/to/the/file.cer') }}"
     private_key: "{{lookup('file', 'path/to/the/file.key') }}"
     password: "{{ sso_keystore_pass }}"
-    dest: /etc/security/keystore.jks
+    dest: "{{ sso_keystore_path }}"
 
 - name: 'Add a new SSL based security-realm'
   shell: >
@@ -27,15 +27,20 @@
     --command='/core-service=management/security-realm=UndertowRealm:add()'
   args:
     executable: "/bin/bash"
-  ignore_errors: yes
+  register: process_undertowrealm
+  failed_when:
+    - process_undertowrealm.rc == 1
+    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
 
 - name: 'Configure security-realm to use the keystore'
   shell: >
     "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path=/etc/security/keystore.jks, keystore-password="{{ sso_keystore_pass }}")'
+    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ sso_keystore_path }}", keystore-password="{{ sso_keystore_pass }}")'
   args:
     executable: "/bin/bash"
-  ignore_errors: yes
+  failed_when:
+    - process_undertowrealm.rc == 1
+    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
 
 - name: 'Point the https-listener to the security-realm'
   shell: >
@@ -43,7 +48,9 @@
     --command='/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm, value=UndertowRealm)'
   args:
     executable: "/bin/bash"
-  ignore_errors: yes
+  failed_when:
+    - process_undertowrealm.rc == 1
+    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
 
 - name: 'Add a default SSO administration user'
   shell: >
@@ -52,7 +59,6 @@
     --password "{{ sso_admin_pass }}"
   args:
     executable: "/bin/bash"
-  ignore_errors: yes
 
 - name: 'Start Red Hat SSO in Standalone mode'
   service:

--- a/roles/config-rh-sso/tasks/setup-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso.yml
@@ -51,6 +51,7 @@
     --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ sso_keystore_path }}", keystore-password="{{ sso_keystore_pass }}")'
   args:
     executable: "/bin/bash"
+  register: process_undertowrealm
   failed_when:
     - process_undertowrealm.rc == 1
     - "'WFLYCTL0212' not in process_undertowrealm.stdout"
@@ -61,6 +62,7 @@
     --command='/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm, value=UndertowRealm)'
   args:
     executable: "/bin/bash"
+  register: process_undertowrealm
   failed_when:
     - process_undertowrealm.rc == 1
     - "'WFLYCTL0212' not in process_undertowrealm.stdout"

--- a/roles/config-rh-sso/templates/realm.json.j2
+++ b/roles/config-rh-sso/templates/realm.json.j2
@@ -1,14 +1,14 @@
 {
-  "id": "{{ realm.id | default(realm.name) }}",
-  "realm": "{{ realm.name }}",
-  "displayName": "{{ realm.displayName }}",
-  "enabled": "{{ realm.enabled | default(true) }}",
-  "sslRequired": "{{ realm.sslRequired | default('external') }}",
-  "registrationAllowed": "{{ realm.registrationAllowed | default(true) }}",
-  "loginWithEmailAllowed": "{{ realm.emailLogin | default(true) }}",
-  "duplicateEmailsAllowed": "{{ realm.dupsAllowed | default(false) }}",
-  "resetPasswordAllowed": "{{ realm.resetPwd | default(false) }}",
-  "editUsernameAllowed": "{{ realm.editUname | default(false) }}",
-  "bruteForceProtected": "{{ realm.bruteForceProtected | default(true) }}"
+  "id": "{{ realm_data.realm_id | default(realm_data.realm_name) }}",
+  "realm": "{{ realm_data.realm_name }}",
+  "displayName": "{{ realm_data.realm_displayName }}",
+  "enabled": "{{ realm_data.realm_enabled | default(true) }}",
+  "sslRequired": "{{ realm_data.realm_sslRequired | default('external') }}",
+  "registrationAllowed": "{{ realm_data.realm_registrationAllowed | default(true) }}",
+  "loginWithEmailAllowed": "{{ realm_data.realm_emailLogin | default(true) }}",
+  "duplicateEmailsAllowed": "{{ realm_data.realm_dupsAllowed | default(false) }}",
+  "resetPasswordAllowed": "{{ realm_data.realm_resetPwd | default(false) }}",
+  "editUsernameAllowed": "{{ realm_data.realm_editUname | default(false) }}",
+  "bruteForceProtected": "{{ realm_data.realm_bruteForceProtected | default(true) }}"
 }
 


### PR DESCRIPTION
### What does this PR do?
This Pull Request brings HTTPS/SSL support for Red Hat Single Sign-On. This is accomplished during the initial setup of instance, meaning that, for the time being, Red Hat SSO cannot be deployed without this feature as it's currently part of the setup.
The method used to implement HTTPS support relies on the usage of `jboss-cli` for the modification of the necessary XML data sources as this will allow us to keep track of all the changes in the files.
This setup currently targets Red Hat SSO `standalone` operation mode.

### How should this be tested?
By deploying Red Hat Single Sign-On application, the user should be forced to use the default https port `8443`, otherwise, an error message should appear, saying that HTTPS is required for web requests.

### Is there a relevant Issue open for this?
resolves #457

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
