### PR TITLE
Allow selection of Tower Version rather than having to provide full download URL

### DIFF
--- a/inventory/ansible-tower/group_vars/ansible-tower.yml
+++ b/inventory/ansible-tower/group_vars/ansible-tower.yml
@@ -1,4 +1,4 @@
 ---
 
-ansible_tower_download_url: "https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.3.0-1.tar.gz"
+ansible_tower_version: 3.3.0-1
 

--- a/roles/ansible/tower/config-ansible-tower/README.md
+++ b/roles/ansible/tower/config-ansible-tower/README.md
@@ -16,6 +16,8 @@ The variables used to install an Ansible Tower instance are outlined in the tabl
 
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
+|ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
+|ansible_tower_version|Version of Ansible Tower to install|no|'3.3.0-1'|
 |ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
 |ansible_tower.install.pg.host|PostgreSQL hostname to listen on|no|nothing ('')|
 |ansible_tower.install.pg.host|PostgreSQL port to listen on|no|nothing ('')|
@@ -31,12 +33,14 @@ The variables used to install an Ansible Tower instance are outlined in the tabl
 |ansible_tower.install.ssl_certificate.cert|Custom SSL certificate to use for Tower UI|no||
 |ansible_tower.install.ssl_certificate.key|Custom SSL key to use with above mentioned certificate for Tower UI|no||
 
+_Note that `ansible_tower.install.rabbitmq` is unused when `ansible_tower_version >= 3.7.0`._
+
 
 ## Example Inventory
 
 ```yaml
 ---
-
+ansible_tower_version: "3.6.4-1:
 ansible_tower:
   admin_password: 'admin'
   install:
@@ -59,7 +63,7 @@ ansible_tower:
 
 - hosts: tower
   roles:
-  - role: config-ansibletower
+  - role: config-ansible-tower
 ```
 
 

--- a/roles/ansible/tower/config-ansible-tower/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 
 # ansible_tower_download_url: http://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-latest.tar.gz
-ansible_tower_download_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.3.0-1.tar.gz
+ansible_tower_download_url: "https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz"
+
+ansible_tower_version: 3.3.0-1
 
 # oc clients found at 'https://mirror.openshift.com/pub/openshift-v3/clients/'
 ansible_tower_oc_download_url: https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz

--- a/roles/ansible/tower/config-ansible-tower/tasks/install.yml
+++ b/roles/ansible/tower/config-ansible-tower/tasks/install.yml
@@ -22,7 +22,7 @@
       # is the directory so set that as ansible_tower_dir
       ansible_tower_dir: "{{ ansible_tower_download_fact.files.0 }}"
       # Need to check if version 3.7 or later as we use different inventory values
-      ansible_tower_37_later: "{{ ansible_tower_version is version(3.7, '>=') }}"
+      ansible_tower_37_later: "{{ (ansible_tower_version is version(3.7, '>=')) or (ansible_tower_version == 'latest') }}"
 
   - name: "Set up the Ansible Tower inventory"
     template:

--- a/roles/ansible/tower/config-ansible-tower/tasks/install.yml
+++ b/roles/ansible/tower/config-ansible-tower/tasks/install.yml
@@ -16,11 +16,13 @@
       exclude: "inventory"
     register: ansible_tower_download_fact
 
-  # The first file listed in the output of the unarchiving from downloading tower
-  # is the directory so set that as ansible_tower_dir
-  - name: "Set installation dir fact"
+  - name: "Set installation facts"
     set_fact:
+      # The first file listed in the output of the unarchiving from downloading tower
+      # is the directory so set that as ansible_tower_dir
       ansible_tower_dir: "{{ ansible_tower_download_fact.files.0 }}"
+      # Need to check if version 3.7 or later as we use different inventory values
+      ansible_tower_37_later: "{{ ansible_tower_version is version(3.7, '>=') }}"
 
   - name: "Set up the Ansible Tower inventory"
     template:

--- a/roles/ansible/tower/config-ansible-tower/templates/inventory.j2
+++ b/roles/ansible/tower/config-ansible-tower/templates/inventory.j2
@@ -13,9 +13,13 @@ pg_database="{{ ansible_tower.install.pg.database | default('awx') }}"
 pg_username="{{ ansible_tower.install.pg.username | default('awx') }}"
 pg_password="{{ ansible_tower.install.pg.password | default(ansible_tower.admin_password) }}"
 
+{% if not ansible_tower_37_later %}
+
 rabbitmq_port="{{ ansible_tower.install.rabbitmq.port | default(5672) }}"
 rabbitmq_vhost="{{ ansible_tower.install.rabbitmq.vhost | default('tower') }}"
 rabbitmq_username="{{ ansible_tower.install.rabbitmq.username | default('tower') }}"
 rabbitmq_password='{{ ansible_tower.install.rabbitmq.password | default(ansible_tower.admin_password) }}'
 rabbitmq_cookie="{{ ansible_tower.install.rabbitmq.cookie | default('cookiemonster') }}"
 rabbitmq_use_long_name="{{ ansible_tower.install.rabbitmq.use_long_name | default(false) }}"
+
+{% endif %}

--- a/test.yml
+++ b/test.yml
@@ -1,8 +1,0 @@
----
-- hosts: localhost
-  vars:
-    ver: 3.6.4-2
-  tasks:
-    - debug:
-        msg: "true"
-      when: (ver == 'latest') or (ver is version('3.7', '>='))

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  vars:
+    ver: 3.6.4-2
+  tasks:
+    - debug:
+        msg: "true"
+      when: (ver == 'latest') or (ver is version('3.7', '>='))


### PR DESCRIPTION
### What does this PR do?
Allows for installation of different versions of Ansible Tower rather than having to provide `ansible_tower_download_url`. This should be backward compatible as I have just pulled out the version from the url and placed it into its own variable.

Additionally I have done some templating on the `inventory.j2` to not place the rabbitmq variables if version>=3.7.0.

Only additional thing is we could change `ansible_tower_version` by default to be `latest`, but just wanted to make sure there is nothing dependant on version being defaulted to `3.3.0-1`

### How should this be tested?
Using defaults with `ansible_tower_version=3.6.4-1` the following inventory file is given:
```
[xxx@xxx ansible-tower-setup-3.6.4-1]$ cat inventory 

[tower]
localhost ansible_connection=local

[database]

[all:vars]
admin_password='admin01'

pg_host=""
pg_port=""
pg_database="awx"
pg_username="awx"
pg_password="pg_password01"


rabbitmq_port="5672"
rabbitmq_vhost="tower"
rabbitmq_username="tower"
rabbitmq_password='admin01'
rabbitmq_cookie="cookiemonster"
rabbitmq_use_long_name="False"
```

Using defaults with `ansible_tower_version=3.7.1-1` the following inventory file is given:
```
[xxx@xxx ansible-tower-setup-3.7.1-1]$ cat inventory 

[tower]
localhost ansible_connection=local

[database]

[all:vars]
admin_password='admin01'

pg_host=""
pg_port=""
pg_database="awx"
pg_username="awx"
pg_password="pg_password01"
```

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
