### PR TITLE
Making AWS Profile optional

### DIFF
--- a/playbooks/manage-identities/manage-aws-identities.yml
+++ b/playbooks/manage-identities/manage-aws-identities.yml
@@ -7,8 +7,3 @@
     - role: identity-management/manage-aws-identities
     - role: identity-management/manage-user-password
     - role: identity-management/manage-aws-user-password
-
-- name: "Notify users"
-  import_playbook: ../notifications/email-notify-users.yml
-  vars:
-    users: "{{ identities.users }}"

--- a/playbooks/manage-identities/process-and-notify-users.yml
+++ b/playbooks/manage-identities/process-and-notify-users.yml
@@ -6,8 +6,8 @@
   roles:
     - identity-management/populate-users
 
-- name: "Manage the identities in IPA/IdM"
-  import_playbook: manage-idm-identities.yml
+- name: "Manage the identities first"
+  import_playbook: manage-identities.yml
 
 - name: "Notify users"
   import_playbook: ../notifications/email-notify-users.yml

--- a/roles/identity-management/manage-aws-identities/tasks/create_groups.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/create_groups.yml
@@ -5,7 +5,7 @@
     name: "{{ group_data.group_name }}"
     managed_policy: "{{ group_data.managed_policy_arn|default(omit) }}"
     users: "{{ group_data.members|default(omit) }}"
-    profile: "{{ identities.profile_name }}"
+    profile: "{{ identities.profile_name | default(omit) }}"
     state: present
   loop: "{{ identities.groups }}"
   loop_control:

--- a/roles/identity-management/manage-aws-identities/tasks/create_policies.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/create_policies.yml
@@ -7,7 +7,7 @@
     policy: "{{ policy_data.policy|from_yaml }}"
     make_default: "{{ policy_data.make_default|default(omit) }}"
     only_version: "{{ policy_data.only_version|default(omit) }}"
-    profile: "{{ identities.profile_name }}"
+    profile: "{{ identities.profile_name | default(omit) }}"
     state: present
   loop: "{{ identities.policies }}"
   loop_control:

--- a/roles/identity-management/manage-aws-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/create_users.yml
@@ -6,7 +6,7 @@
       iam_user:
         name: "{{ user_data.user_name }}"
         state: present
-        profile: "{{ identities.profile_name }}"
+        profile: "{{ identities.profile_name | default(omit) }}"
       register: aws_user_list
       loop: "{{ identities.users }}"
       loop_control:
@@ -20,7 +20,7 @@
         list_of_users: []
     - name: "Create password generation dataset"
       set_fact:
-        list_of_users: "{{ list_of_users + [ aws_data.user_data|combine(aws_data|set_user_flags, {'aws_profile': identities.profile_name}) ] }}"
+        list_of_users: "{{ list_of_users + [ aws_data.user_data|combine(aws_data|set_user_flags, {'aws_profile': identities.profile_name|default('')}) ] }}"
       with_items:
         - "{{ aws_user_list.results }}"
       loop_control:

--- a/roles/identity-management/manage-aws-identities/tasks/delete_groups.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/delete_groups.yml
@@ -4,7 +4,7 @@
   iam_group:
     name: "{{ group_data.group_name }}"
     state: absent
-    profile: "{{ identities.profile_name }}"
+    profile: "{{ identities.profile_name | default(omit) }}"
   loop: "{{ identities.groups }}"
   loop_control:
     loop_var: group_data

--- a/roles/identity-management/manage-aws-identities/tasks/delete_policies.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/delete_policies.yml
@@ -4,7 +4,7 @@
   iam_managed_policy:
     policy_name: "{{ policy_data.policy_name }}"
     state: absent
-    profile: "{{ identities.profile_name }}"
+    profile: "{{ identities.profile_name | default(omit) }}"
   loop: "{{ identities.policies }}"
   loop_control:
     loop_var: policy_data

--- a/roles/identity-management/manage-aws-identities/tasks/delete_users.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/delete_users.yml
@@ -5,7 +5,7 @@
     name: "{{ user_data.user_name }}"
     state: absent
     groups: ""
-    profile: "{{ identities.profile_name }}"
+    profile: "{{ identities.profile_name | default(omit) }}"
   loop: "{{ identities.users }}"
   loop_control:
     loop_var: user_data

--- a/roles/identity-management/manage-aws-identities/tasks/main.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/main.yml
@@ -10,4 +10,3 @@
 
   when:
     - identities.targets is undefined or 'aws' in identities.targets
-    - identities.profile_name|length > 0


### PR DESCRIPTION
### What does this PR do?
Two changes:

1. Updated AWS identity  management to make profile optional as it's not a required field to run the automation
2. Updated playbooks to align with other playbooks for AWS identity management

### How should this be tested?
Create  an inventory based on the role as-is, but omit the profile info

### Is there a relevant Issue open for this?

N/A

### Other Relevant info, PRs, etc.

N/A

### People to notify
cc: @redhat-cop/infra-ansible
