### PR TITLE
Add initial SSO clients tasks

### DIFF
--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -25,3 +25,34 @@ realms:
     id: simple-realm
     displayName: "Simple Times"
     enabled: false
+
+clients:
+  - auth_url: "https://my-sso.example.com"
+    name: "my-super-fun-client"
+    enabled: true
+    auth_client_id: "admin-client"
+    auth_realm: "master"
+    auth_username: "admin"
+    auth_password: "password123"
+    consent_required: false
+    public_access: true
+    standard_flow: true
+    implicit_flow: true
+    direct_access_grants: true
+    realm: "my-awesome-realm"
+    protocol: "openid-connect"
+    redirect_uris:
+      - "*"
+    web_origins:
+      - "+"
+    protocol_mappers:
+      - config:
+          claim.name: "my-claim-name"
+          id.token.claim: true
+          userinfo.token.claim: true
+          access.token.claim: true
+          multivalued: true
+        name: my-claim-name
+        consentRequired: false
+        protocolMapper: "oidc-usermodel-realm-role-mapper"
+        protocol: openid-connect

--- a/roles/config-rh-sso/README.md
+++ b/roles/config-rh-sso/README.md
@@ -9,8 +9,48 @@ Active Red Hat Subscription to enable repositories and download the SSO package 
 ## Dependencies
 None
 
+## Clients
 
-### Example Playbook
+| Variable | Description | Required | Defaults |
+|:---------|:------------|:---------|:---------|
+|clients.auth_client|OpenID Connect client_id to authenticate to the API with.|N|`admin-cli`|
+|clients.auth_url|URL for Keycloak instance. Defaults to instance that was created if your inventory creates an instance.|N|`https://rh-sso-host:443/auth`|
+|clients.auth_realm|Keycloak Realm Name. Defaults to the default keycloak realm.|N|`master`|
+|clients.auth_user|Keycloak user to authenticate with. Defaults to the admin user if specified.|N|`sso_admin_user`|
+|clients.auth_password|Password for keycloak user you wish to authenticate with.|N|`sso_admin_pass`|
+|clients.state|Checks whether client should exist or not|N|`present`|
+|clients.realm|The name of the realm that you would like to create this client in.|N|`N/A`|
+|clients.name|The name of the client that you would like to create|Y|`N/A`|
+|clients.description|A description for the client. Defaults to the name that you provide.|N|`clients.name`|
+|clients.enabled|Whether the client should be enabled.|N|`true`|
+|clients.base_url|The base url of your application that keycloak should use to redirect requests to your application.|N|`N/A`|
+|clients.admin_url|The url that keycloak will push administrative calls to your application.|N|`N/A`|
+|clients.root_url|The url that keycloak will prepend to any calls made with relative paths.|N|`N/A`|
+|clients.client_auth_type|How your client will interact with keycloak. Valid values are `client-secret` or `client-jwt`. If using `client-secret` you can set the secret through the `clients.secret` field. If using `client-jwt` you can set `use.jwks.url`, `jwks.url` and `jwt.credential.certificate` in the `clients.attributes` field.|N|`N/A`|
+|clients.client_auth_secret|The secret to be used when `clients.client_auth_type` is set to `client-secret`. This field is ignored if it is not set to `client-secret`.|N|`N/A`|
+|clients.redirect_uris|A list of valid redirect URIs for use with this client|N|`N/A`|
+|clients.web_origins|A list of allowed CORS origins for use with this client|N|`N/A`|
+|clients.bearer_only|Whether the access type of this client should be bearer-only.|N|`false`|
+|clients.consent_req|Whether to ask for consent from users for access with the client|N|`false`|
+|clients.standard_flow|Whether to enable standard flow (OIDC) for this client.|N|`false`|
+|clients.implicit_flow|Whether to enable implicit flow (OIDS) for this client.|N|`false`|
+|clients.direct_access_grants|Whether to enable direct access grants for this client.|N|`false`|
+|clients.svc_acct_enabled|Whether to enable service accounts for this client.|N|`false`|
+|clients.auth_svc_enabled|Whether to enable authorization services for this client|N|`false`|
+|clients.public_access|Is this a public client or not|N|`false`|
+|clients.frontchannel_logout|Whether to enable frontchannel logout for this client|N|`false`|
+|clients.protocol|The type of client to create. Valid values for this are `saml` or `openid-connect`.|N|`N/A`|
+|clients.full_scope_allowed|Whether the full scope allowed feature set is enabled for this client|N|`false`|
+|clients.template|The name of the template to use for this client.|N|`''`|
+|clients.use_template|Whether to use configuration from the specified template.|N|`false`|
+|clients.use_template_scope|Whether to use scope configuration from the specified template.|N|`false`|
+|clients.use_template_mappers|Whether to use mapper configurations from the specified template.|N|`false`|
+|clients.surrogate_auth_req|Whether or not surrogoate authentication is required|N|`false`|
+|clients.default_roles|List of default roles to use with this client.|N|`N/A`|
+|clients.protocol_mappers|List of dicts defining protocol mappers for this client.|N|`N/A`|
+|clients.attributes|A dict of further attributes to use with this client.|N|`N/A`|
+
+## Example Playbook
 ```
 - hosts: rh-sso-hosts
   become: yes

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -5,3 +5,11 @@ rh_sso_port: 8080
 rh_sso_port_list:
   - 8080/tcp
   - 9990/tcp
+
+client_vars:
+  authenticator_type_opts:
+    - client-secret
+    - client-jwt
+  protocol_opts:
+    - openid-connect
+    - saml

--- a/roles/config-rh-sso/tasks/main.yml
+++ b/roles/config-rh-sso/tasks/main.yml
@@ -8,6 +8,6 @@
   loop_control:
     loop_var: realm
 - include_tasks: 'manage-clients.yml'
-  loop: "{{ clients }}"
+  loop: "{{ clients | default([]) }}"
   loop_control:
     loop_var: client

--- a/roles/config-rh-sso/tasks/main.yml
+++ b/roles/config-rh-sso/tasks/main.yml
@@ -7,3 +7,7 @@
   loop: "{{ realms }}"
   loop_control:
     loop_var: realm
+- include_tasks: 'manage-clients.yml'
+  loop: "{{ clients }}"
+  loop_control:
+    loop_var: client

--- a/roles/config-rh-sso/tasks/manage-clients.yml
+++ b/roles/config-rh-sso/tasks/manage-clients.yml
@@ -2,7 +2,7 @@
 
 - name: Check for valid client_authenticator_type value
   set_fact:
-    invalid: "{{ '' if (client.client_authenticator_type | default('')) in client_vars.authenticator_type_opts else 'client_authenticator_type' }}"
+    invalid_field: "{{ '' if (client.client_authenticator_type | default('')) in client_vars.authenticator_type_opts else 'client_authenticator_type' }}"
   when:
     - client.client_authenticator_type is defined
 
@@ -11,12 +11,12 @@
     msg: "Skipping creation of client: {{ client.name }} due to invalid client_authenticator_type value."
   ignore_errors: yes
   when:
-    - invalid is defined
-    - invalid == "client_authenticator_type"
+    - invalid_field is defined
+    - invalid_field == "client_authenticator_type"
 
 - name: Check for valid protocol value
   set_fact:
-    invalid: "{{ '' if (client.protocol | default('')) in client_vars.protocol_opts else 'protocol' }}"
+    invalid_field: "{{ '' if (client.protocol | default('')) in client_vars.protocol_opts else 'protocol' }}"
   when:
     - client.protocol is defined
 
@@ -25,8 +25,8 @@
     msg: "Skipping creation of client: {{ client.name }} due to invalid protocol value."
   ignore_errors: yes
   when:
-    - invalid is defined
-    - invalid == "protocol"
+    - invalid_field is defined
+    - invalid_field == "protocol"
 
 - name: Set secret value if using client-secret authentication
   set_fact:
@@ -76,4 +76,4 @@
     attributes: "{{ client.attributes | default(omit) }}"
     public_client: "{{ client.public_access | default(false) }}"
   when:
-    - invalid == ""
+    - invalid_field|trim == ""

--- a/roles/config-rh-sso/tasks/manage-clients.yml
+++ b/roles/config-rh-sso/tasks/manage-clients.yml
@@ -1,0 +1,79 @@
+---
+
+- name: Check for valid client_authenticator_type value
+  set_fact:
+    invalid: "{{ '' if (client.client_authenticator_type | default('')) in client_vars.authenticator_type_opts else 'client_authenticator_type' }}"
+  when:
+    - client.client_authenticator_type is defined
+
+- name: "Invalid client_authenticator_type"
+  fail: 
+    msg: "Skipping creation of client: {{ client.name }} due to invalid client_authenticator_type value."
+  ignore_errors: yes
+  when:
+    - invalid is defined
+    - invalid == "client_authenticator_type"
+
+- name: Check for valid protocol value
+  set_fact:
+    invalid: "{{ '' if (client.protocol | default('')) in client_vars.protocol_opts else 'protocol' }}"
+  when:
+    - client.protocol is defined
+
+- name: "Invalid protocol"
+  fail:
+    msg: "Skipping creation of client: {{ client.name }} due to invalid protocol value."
+  ignore_errors: yes
+  when:
+    - invalid is defined
+    - invalid == "protocol"
+
+- name: Set secret value if using client-secret authentication
+  set_fact:
+    secret: "{{ client.client_auth_secret }}" 
+  when: 
+    - client.client_auth_secret is defined
+    - client.client_authenticator_type is defined
+    - client.client_authenticator_type != 'client-secret')
+
+- name: "Create client: {{ client.name | mandatory }} in realm: {{ client.realm | mandatory }}"
+  keycloak_client:
+    auth_client_id: "{{ client.auth_client | default('admin-cli') }}"
+    auth_keycloak_url: "{{ client.auth_url | default('https://' + rh_sso_host + ':' + (rh_sso_port | string)) + '/auth' }}"
+    auth_realm: "{{ client.auth_realm | default('master') }}"
+    auth_username: "{{ client.auth_user | default(sso_admin_user) }}"	
+    auth_password: "{{ client.auth_password | default(sso_admin_pass) }}"
+    state: "{{ client.state | default('present') }}"
+    realm: "{{ client.realm | default(omit) }}"
+    client_id: "{{ client.name | mandatory}}"
+    name: "{{ client.name | mandatory }}"
+    description: "{{ client.description | default(client.name) }}"
+    enabled: "{{ client.enabled | default(true) }}"
+    base_url: "{{ client.base_url | default(omit) }}"
+    admin_url: "{{ client.admin_url | default(omit) }}"
+    root_url: "{{ client.root_url | default(omit) }}"
+    client_authenticator_type: "{{ client.client_auth_type | default(omit) }}"
+    secret: "{{ secret | default(omit) }}"
+    redirect_uris: "{{ client.redirect_uris | default(omit) }}"
+    web_origins: "{{ client.web_origins | default(omit) }}"
+    bearer_only: "{{ client.bearer_only | default(false) }}"
+    consent_required: "{{ client.consent_req | default(false) }}"
+    standard_flow_enabled: "{{ client.standard_flow | default(false) }}"
+    implicit_flow_enabled: "{{ client.implicit_flow | default(false) }}"
+    direct_access_grants_enabled: "{{ client.direct_access_grants | default(false) }}"
+    service_accounts_enabled: "{{ client.svc_acct_enabled | default(false) }}"
+    authorization_services_enabled: "{{ client.auth_svc_enabled | default(false) }}"
+    frontchannel_logout: "{{ client.frontchannel_logout | default(false) }}"
+    protocol: "{{ client.protocol | default(omit) }}"
+    full_scope_allowed: "{{ client.full_scope_allowed | default(false) }}"
+    client_template: "{{ client.template | default('') }}"
+    use_template_config: "{{ client.use_template | default(false) }}"
+    use_template_scope: "{{ client.use_template_scope | default(false) }}"
+    use_template_mappers: "{{ client.use_template_mappers | default(false) }}"
+    surrogate_auth_required: "{{ client.surrogate_auth_req | default(false) }}" 
+    default_roles: "{{ client.default_roles | default(omit)}}"
+    protocol_mappers: "{{ client.protocol_mappers | default(omit) }}"
+    attributes: "{{ client.attributes | default(omit) }}"
+    public_client: "{{ client.public_access | default(false) }}"
+  when:
+    - invalid == ""

--- a/roles/config-rh-sso/tasks/manage-clients.yml
+++ b/roles/config-rh-sso/tasks/manage-clients.yml
@@ -76,4 +76,4 @@
     attributes: "{{ client.attributes | default(omit) }}"
     public_client: "{{ client.public_access | default(false) }}"
   when:
-    - invalid_field|trim == ""
+    - invalid_field is undefined or invalid_field|trim == ""


### PR DESCRIPTION
### What does this PR do?
This adds the ability to configure a list of SSO clients against a Keycloak/RH SSO server and realm.

### How should this be tested?
This can be tested with the example inventory that is provided

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible

cc/ @oybed @BinaryDevotee @jtudelag 
