### PR TITLE
Add ability to update existing SSO realm

### DIFF
--- a/roles/config-rh-sso/tasks/main.yml
+++ b/roles/config-rh-sso/tasks/main.yml
@@ -4,8 +4,8 @@
 - import_tasks: 'prereq.yml'
 - import_tasks: 'setup-rh-sso.yml'
 
-- include_tasks: 'create_realm.yml'
-  loop: "{{ realms }}"
+- include_tasks: 'manage-realms.yml'
+  loop: "{{ realms | default([]) }}"
   loop_control:
     loop_var: realm_data
   tags: create-realm

--- a/roles/config-rh-sso/tasks/manage-realms.yml
+++ b/roles/config-rh-sso/tasks/manage-realms.yml
@@ -23,6 +23,7 @@
     method: GET
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
   register: rh_sso_realms
 
 - name: "Check If Realm {{ realm_data.name }} exists"

--- a/roles/config-rh-sso/tasks/manage-realms.yml
+++ b/roles/config-rh-sso/tasks/manage-realms.yml
@@ -19,7 +19,7 @@
 
 - name: "Get Existing Realms"
   uri:
-    url: "https://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
+    url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
     method: GET
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"

--- a/roles/config-rh-sso/tasks/manage-realms.yml
+++ b/roles/config-rh-sso/tasks/manage-realms.yml
@@ -17,6 +17,20 @@
     validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
   register: rh_sso_token
 
+- name: "Get Existing Realms"
+  uri:
+    url: "https://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
+  register: rh_sso_realms
+
+- name: "Check If Realm {{ realm_data.name }} exists"
+  set_fact:
+    realm_check: "{{ rh_sso_realms.json | json_query(query) }}"
+  vars:
+    query: "[?realm=='{{ realm_data.name }}']"
+
 - name: "Create Realm for service Red Hat Single Sign-On"
   uri:
     url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms"
@@ -28,3 +42,18 @@
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
     validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
   register: rh_sso_realm_create
+  when:
+  - realm_check[0] is not defined
+
+- name: "Update Realm: {{ realm_data.name }}"
+  uri:
+    url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms/{{ realm_data.name }}"
+    method: PUT
+    body: "{{ realm_json }}"
+    body_format: json
+    status_code: 204
+    headers:
+      Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+  when:
+  - realm_check[0] is defined

--- a/roles/config-rh-sso/templates/realm.json.j2
+++ b/roles/config-rh-sso/templates/realm.json.j2
@@ -1,7 +1,7 @@
 {
   "id": "{{ realm_data.id | default(realm_data.name) }}",
-  "realm": "{{ realm_data.name }}",
-  "displayName": "{{ realm_data.displayName }}",
+  "realm": "{{ realm_data.name | mandatory }}",
+  "displayName": "{{ realm_data.displayName | default(realm_data.name) }}",
   "enabled": "{{ realm_data.enabled | default(true) }}",
   "sslRequired": "{{ realm_data.sslRequired | default('external') }}",
   "registrationAllowed": "{{ realm_data.registrationAllowed | default(true) }}",


### PR DESCRIPTION
### What does this PR do?
This adds the ability to update an existing SSO realm in keycloak/RH SSO

### How should this be tested?
The example inventory provided in this repo can be run to create an initial realm. Then you can go to that inventory and update something like the description and rerun the playbook. The update task will then be run and you'll be able to see the updated field.

### Is there a relevant Issue open for this?
resolves #499

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible @BinaryDevotee 
