### PR TITLE
WIP: Update identity-management role to add idm groups to other groups

### DIFF
--- a/roles/identity-management/README.md
+++ b/roles/identity-management/README.md
@@ -42,6 +42,9 @@ identities:
         - gdownie
         - lcohen
         - rhawkins
+      childgroups:
+        - ops
+        - devs
     - name: "test-group2"
       members:
         - rhawkins

--- a/roles/identity-management/manage-idm-identities/tasks/create_groups.yml
+++ b/roles/identity-management/manage-idm-identities/tasks/create_groups.yml
@@ -9,6 +9,7 @@
     state: "{{ group.state | default(omit) }}"
     name: "{{ group.name | trim }}"
     user: "{{ group.members | default(omit) }}"
+    group: "{{ group.childgroups | default(omit) }}"
   with_items:
     - "{{ identities.groups }}"
   loop_control:


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to add idm groups to other groups and can be specified in the overall `identity-management` structure that we have defined.

### How should this be tested?
Run the example inventory that is provided in this repository

### Is there a relevant Issue open for this?

resolves #475 

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
