### PR TITLE
Adjust variable filters for client creation/update on Red Hat Single Sign-On

### DIFF
--- a/roles/config-rh-sso/tasks/manage-clients.yml
+++ b/roles/config-rh-sso/tasks/manage-clients.yml
@@ -75,9 +75,23 @@
     protocol_mappers: "{{ client.protocol_mappers | default(omit) }}"
     attributes: "{{ client.attributes | default(omit) }}"
     public_client: "{{ client.public_access | default(false) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}" 
   register: rh_sso_client
   when:
     - invalid_field is undefined or invalid_field|trim == ""
+
+- name: "Requesting Access Token"
+  uri:
+    url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      username: "{{ sso_admin_user }}"
+      password: "{{ sso_admin_pass }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+  register: rh_sso_token
 
 - name: "Get Authentication Flows For Realm: {{ client.realm }}"
   uri:
@@ -124,3 +138,4 @@
   when:
   - invalid_field is undefined or invalid_field|trim == ""
   - client.authflow_overrides is defined
+  - browser_override|length > 0


### PR DESCRIPTION
### What does this PR do?
This PR adds the necessary tasks to request an access token against Red Hat Single Sign-On API so that the clients specified in the inventory files can be processed and created.
Additionally, this PR adds a filter that allows the clients to be created independently from any previous steps being executed in advance, which can be useful to create clients against an existing SSO instance.

### How should this be tested?
By using the sample Inventory files provided with this role.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
