### PR TITLE
Fix RH SSO SSL cert & key path

### DIFF
--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -9,9 +9,13 @@ list_of_packages_to_install:
 rh_sso_admin_user: admin
 rh_sso_admin_pass: mypa55ss
 rh_sso_protocol: https
-rh_sso_keystore_name: default
-rh_sso_keystore_pass: changeit
-rh_sso_keystore_path: "/etc/security/keystore.jks"
+
+rh_sso_ssl:
+  cert: /the/path/to/my/cert.crt
+  key: /the/path/to/my/cert.key
+  keystore_name: default
+  keystore_pass: changeit
+  keystore_path: "/etc/security/keystore.jks"
 
 realms:
   - name: my-awesome-realm

--- a/inventory/rh-sso/group_vars/rh-sso-hosts.yml
+++ b/inventory/rh-sso/group_vars/rh-sso-hosts.yml
@@ -8,8 +8,8 @@ list_of_packages_to_install:
 
 rh_sso_admin_user: admin
 rh_sso_admin_pass: mypa55ss
-rh_sso_protocol: https
 
+rh_sso_protocol: https
 rh_sso_ssl:
   cert: /the/path/to/my/cert.crt
   key: /the/path/to/my/cert.key

--- a/playbooks/provision-rh-sso/main.yml
+++ b/playbooks/provision-rh-sso/main.yml
@@ -2,37 +2,39 @@
 
 - import_playbook: ../prep.yml
   when:
-  - rhsm_register|default(False)
+    - rhsm_register|default(False)
   tags:
-  - 'never'
-  - 'install'
+    - 'never'
+    - 'install'
 
 - import_playbook: ../osp/manage-user-network.yml
   when:
-  - hosting_infrastructure == 'openstack'
+    - hosting_infrastructure == 'openstack'
   tags:
-  - 'never'
-  - 'install'
+    - 'never'
+    - 'install'
 
 - import_playbook: ../osp/provision-osp-instance.yml
   when:
-  - hosting_infrastructure == 'openstack'
+    - hosting_infrastructure == 'openstack'
   tags:
-  - 'never'
-  - 'install'
+    - 'never'
+    - 'install'
 
 - import_playbook: ../rhsm.yml
   tags:
-  - 'never'
-  - 'install'
+    - 'never'
+    - 'install'
 
 - hosts: rh-sso-hosts
+  vars:
+    pkg_update: True
   roles:
-  - role: update-host
+    - role: update-host
   tags:
-  - 'never'
-  - 'install'
+    - 'never'
+    - 'install'
 
 - import_playbook: deploy-rh-sso.yml
   tags:
-  - 'always'
+    - 'always'

--- a/roles/config-rh-sso/defaults/main.yml
+++ b/roles/config-rh-sso/defaults/main.yml
@@ -15,6 +15,3 @@ client_vars:
     - openid-connect
     - saml
 
-rh_sso_keystore_name: default
-rh_sso_keystore_pass: changeit
-rh_sso_keystore_path: "/etc/security/keystore.jks"

--- a/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
@@ -1,0 +1,49 @@
+---
+
+- name: 'Error out if no certs provided when ssl mode is enabled'
+  fail:
+    msg: "Required parameters for SSL mode not supplied"
+  when:
+    - rh_sso_ssl is undefined or rh_sso_ssl.cert is undefined or rh_sso.ssl.key is undefined
+
+- name: 'Create a keystore to store SSL certificates'
+  java_keystore:
+    name: "{{ rh_sso_ssl.keystore_name, default('default') }}"
+    password: "{{ rh_sso_ssl.keystore_pass | default('changeit') }}"
+    dest: "{{ rh_sso_ssl.keystore_path | default('/etc/security/keystore.jks') }}"
+    certificate: "{{ lookup('file', rh_sso_ssl.cert) }}"
+    private_key: "{{ lookup('file', rh_sso_ssl.key) }}"
+
+- name: 'Add a new SSL based security-realm'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/core-service=management/security-realm=UndertowRealm:add()'
+  args:
+    executable: "/bin/bash"
+  register: process_undertowrealm
+  failed_when:
+    - process_undertowrealm.rc == 1
+    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
+
+- name: 'Configure security-realm to use the keystore'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ rh_sso_keystore_path }}", keystore-password="{{ rh_sso_keystore_pass }}")'
+  args:
+    executable: "/bin/bash"
+  register: process_undertowrealm
+  failed_when:
+    - process_undertowrealm.rc == 1
+    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
+
+- name: 'Point the https-listener to the security-realm'
+  shell: >
+    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
+    --command='/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm, value=UndertowRealm)'
+  args:
+    executable: "/bin/bash"
+  register: process_undertowrealm
+  failed_when:
+    - process_undertowrealm.rc == 1
+    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
+

--- a/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
@@ -6,11 +6,17 @@
   when:
     - rh_sso_ssl is undefined or rh_sso_ssl.cert is undefined or rh_sso_ssl.key is undefined
 
+- name: 'Set keystore values to use'
+  set_fact:
+    ssl_keystore_name: "{{ rh_sso_ssl.keystore_name | default('default') }}"
+    ssl_keystore_path: "{{ rh_sso_ssl.keystore_path | default('/etc/security/keystore.jks') }}"
+    ssl_keystore_password: "{{ rh_sso_ssl.keystore_pass | default('changeit') }}"
+
 - name: 'Create a keystore to store SSL certificates'
   java_keystore:
-    name: "{{ rh_sso_ssl.keystore_name | default('default') }}"
-    password: "{{ rh_sso_ssl.keystore_pass | default('changeit') }}"
-    dest: "{{ rh_sso_ssl.keystore_path | default('/etc/security/keystore.jks') }}"
+    name: "{{ ssl_keystore_name }}"
+    dest: "{{ ssl_keystore_path }}"
+    password: "{{ ssl_keystore_password }}"
     certificate: "{{ lookup('file', rh_sso_ssl.cert) }}"
     private_key: "{{ lookup('file', rh_sso_ssl.key) }}"
 
@@ -28,7 +34,7 @@
 - name: 'Configure security-realm to use the keystore'
   shell: >
     "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ rh_sso_keystore_path }}", keystore-password="{{ rh_sso_keystore_pass }}")'
+    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ ssl_keystore_path }}", keystore-password="{{ ssl_keystore_password }}")'
   args:
     executable: "/bin/bash"
   register: process_undertowrealm

--- a/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
@@ -8,7 +8,7 @@
 
 - name: 'Create a keystore to store SSL certificates'
   java_keystore:
-    name: "{{ rh_sso_ssl.keystore_name, default('default') }}"
+    name: "{{ rh_sso_ssl.keystore_name | default('default') }}"
     password: "{{ rh_sso_ssl.keystore_pass | default('changeit') }}"
     dest: "{{ rh_sso_ssl.keystore_path | default('/etc/security/keystore.jks') }}"
     certificate: "{{ lookup('file', rh_sso_ssl.cert) }}"

--- a/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso-ssl.yml
@@ -4,7 +4,7 @@
   fail:
     msg: "Required parameters for SSL mode not supplied"
   when:
-    - rh_sso_ssl is undefined or rh_sso_ssl.cert is undefined or rh_sso.ssl.key is undefined
+    - rh_sso_ssl is undefined or rh_sso_ssl.cert is undefined or rh_sso_ssl.key is undefined
 
 - name: 'Create a keystore to store SSL certificates'
   java_keystore:

--- a/roles/config-rh-sso/tasks/setup-rh-sso.yml
+++ b/roles/config-rh-sso/tasks/setup-rh-sso.yml
@@ -26,46 +26,9 @@
   args:
     executable: "/bin/bash"
 
-- name: 'Create a keystore to store SSL certificates'
-  java_keystore:
-    name: "{{ rh_sso_keystore_name }}"
-    certificate: "{{lookup('file', '../path/to/file.cer') }}"
-    private_key: "{{lookup('file', '../path/to/file.key') }}"
-    password: "{{ rh_sso_keystore_pass }}"
-    dest: "{{ rh_sso_keystore_path }}"
-
-- name: 'Add a new SSL based security-realm'
-  shell: >
-    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/core-service=management/security-realm=UndertowRealm:add()'
-  args:
-    executable: "/bin/bash"
-  register: process_undertowrealm
-  failed_when:
-    - process_undertowrealm.rc == 1
-    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
-
-- name: 'Configure security-realm to use the keystore'
-  shell: >
-    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path="{{ rh_sso_keystore_path }}", keystore-password="{{ rh_sso_keystore_pass }}")'
-  args:
-    executable: "/bin/bash"
-  register: process_undertowrealm
-  failed_when:
-    - process_undertowrealm.rc == 1
-    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
-
-- name: 'Point the https-listener to the security-realm'
-  shell: >
-    "/opt/rh/rh-sso7/root/usr/share/keycloak/bin/jboss-cli.sh" -c
-    --command='/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm, value=UndertowRealm)'
-  args:
-    executable: "/bin/bash"
-  register: process_undertowrealm
-  failed_when:
-    - process_undertowrealm.rc == 1
-    - "'WFLYCTL0212' not in process_undertowrealm.stdout"
+- include_tasks: setup-rh-sso-ssl.yml
+  when:
+    - rh_sso_protocol == 'https'
 
 - name: 'Add a default SSO administration user'
   shell: >


### PR DESCRIPTION
### What does this PR do?
The SSO SSL cert and key paths were hardcoded. This PR changes this to allow for the cert to be passed in. + it also makes the role check if the cert info is supplied when protocol is set to `https`

### How should this be tested?

Install RH SSO with protocol set to `https`. Without the certs specified it will error out. When supplied the installation should work and the certs enabled. .

### Is there a relevant Issue open for this?

N/A

### Other Relevant info, PRs, etc.

N/A

### People to notify
cc: @redhat-cop/infra-ansible
