### PR TITLE
Fixing validate_certs to use 'omit'

### DIFF
--- a/roles/config-rh-sso/tasks/manage-auth-flow-executions.yml
+++ b/roles/config-rh-sso/tasks/manage-auth-flow-executions.yml
@@ -10,7 +10,7 @@
       password: "{{ rh_sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_token
 
 - name: "Check if Execution: {{ af_exec.provider }} exists in Authentication Flow: {{ af.name }}"
@@ -33,7 +33,7 @@
         status_code: 201
         headers:
           Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-        validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+        validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
       register: exec_out
     - name: "Retrieve Template for Execution Flow"
       set_fact:
@@ -47,7 +47,7 @@
         status_code: 204
         headers:
           Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-        validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+        validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
       register: update_out
     - name: "Add config"
       uri:
@@ -60,7 +60,7 @@
         status_code: 201
         headers:
           Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-        validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+        validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   when:
     - exec_check[0] is not defined
 

--- a/roles/config-rh-sso/tasks/manage-auth-flow.yml
+++ b/roles/config-rh-sso/tasks/manage-auth-flow.yml
@@ -12,7 +12,7 @@
       password: "{{ rh_sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_token
 
 - name: "Get Existing Authentication Flows For realm: {{ af.realm }}"
@@ -21,7 +21,7 @@
     method: GET
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_flows
 
 - name: "Check If Authentication Flow: {{ af.name }} exists"
@@ -43,7 +43,7 @@
     status_code: 201
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   when:
     - af_check[0] is not defined
 
@@ -59,7 +59,7 @@
     method: GET
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_exec
 
 - name: "Ensure Execution Flows Exist"

--- a/roles/config-rh-sso/tasks/manage-clients.yml
+++ b/roles/config-rh-sso/tasks/manage-clients.yml
@@ -75,7 +75,7 @@
     protocol_mappers: "{{ client.protocol_mappers | default(omit) }}"
     attributes: "{{ client.attributes | default(omit) }}"
     public_client: "{{ client.public_access | default(false) }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_client
   when:
     - invalid_field is undefined or invalid_field|trim == ""
@@ -90,7 +90,7 @@
       password: "{{ rh_sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_token
 
 - name: "Get Authentication Flows For Realm: {{ client.realm }}"
@@ -99,7 +99,7 @@
     method: GET
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: client_flows
   when:
     - invalid_field is undefined or invalid_field|trim == ""
@@ -134,7 +134,7 @@
     status_code: 204
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   when:
     - invalid_field is undefined or invalid_field|trim == ""
     - client.authflow_overrides is defined

--- a/roles/config-rh-sso/tasks/manage-id-provider.yml
+++ b/roles/config-rh-sso/tasks/manage-id-provider.yml
@@ -14,7 +14,7 @@
       password: "{{ rh_sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_token
 
 - name: "Create Identity Provider for Red Hat Single Sign-On"
@@ -26,5 +26,5 @@
     status_code: 201, 409
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_idp_create

--- a/roles/config-rh-sso/tasks/manage-realms.yml
+++ b/roles/config-rh-sso/tasks/manage-realms.yml
@@ -14,7 +14,7 @@
       password: "{{ rh_sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_token
 
 - name: "Get Existing Realms"
@@ -23,7 +23,7 @@
     method: GET
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_realms
 
 - name: "Check If Realm {{ realm_data.name }} exists"
@@ -41,7 +41,7 @@
     status_code: 201, 409
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_realm_create
   when:
   - realm_check[0] is not defined
@@ -55,6 +55,6 @@
     status_code: 204
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   when:
   - realm_check[0] is defined

--- a/roles/config-rh-sso/tasks/manage-roles.yml
+++ b/roles/config-rh-sso/tasks/manage-roles.yml
@@ -10,7 +10,7 @@
       password: "{{ rh_sso_admin_pass }}"
       grant_type: "password"
       client_id: "admin-cli"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_token
 
 - name: "Retrieve template for role"
@@ -26,5 +26,5 @@
     status_code: 201, 409
     headers:
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-    validate_certs: "{{ rh_sso_ssl_cert_validation | default(yes) }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: rh_sso_role_create


### PR DESCRIPTION
### What does this PR do?
Ansible thinks `default(yes)` means that a variable is defined with the name `yes`. The solution would be to use `default('yes')`. However, since we probably want to just use the default Ansible provides here - with the option to override - we should just use `omit` to fix this problem.

### How should this be tested?

Run through the RH SSO automation and validate that it works correctly for the cert validation

### Is there a relevant Issue open for this?

N/A

### Other Relevant info, PRs, etc.

N/A

### People to notify
cc: @redhat-cop/infra-ansible
