### PR TITLE
Only Lint changed files

### DIFF
--- a/.github/workflow-config/yamllint.yml
+++ b/.github/workflow-config/yamllint.yml
@@ -1,6 +1,11 @@
 ---
 extends: default
 
+ignore: |
+  *
+  !*.yml
+  !*.yaml
+
 rules:
   braces:
     level: warning

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Repo Linter
 
 on: [push, pull_request]
@@ -8,16 +7,28 @@ jobs:
   yaml_lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: yaml-lint
-      uses: ibiqlik/action-yamllint@v1.0.0
-      with:
-        # Path to custom configuration
-        config_file: .github/workflow-config/yamllint.yml
-        # Custom configuration (as YAML source)
-        # config_data: # optional
-        # Format for parsing output [parsable,standard,colored,auto]
-        # format: # optional, default is colored
-        # Return non-zero exit code on warnings as well as errors
-        # strict: # optional, default is false
+      - uses: actions/checkout@v1
 
+      - name: Get file changes
+        id: get_file_changes
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Echo file changes
+        run: |
+          echo Changed files: ${{ join(steps.get_file_changes.outputs.all, ' ') }}
+
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v1.0.0
+        with:
+          # Path to custom configuration
+          config_file: .github/workflow-config/yamllint.yml
+          # Path of changed files
+          file_or_dir: ${{ join(fromJson(steps.get_file_changes.outputs.all), ' ') }}
+          # Custom configuration (as YAML source)
+          # config_data: # optional
+          # Format for parsing output [parsable,standard,colored,auto]
+          # format: # optional, default is colored
+          # Return non-zero exit code on warnings as well as errors
+          # strict: # optional, default is false


### PR DESCRIPTION
### What does this PR do?
Only lints changed files

### How should this be tested?
You can see from runs 19-21 [here](https://github.com/Tompage1994/infra-ansible/actions) that I have pushed a commit which shows only running yamllint against changed files. Then pushing a breaking change has caused a failure, then pushing another unrelated change passes on push.

For PRs you can see all changed files for the PR are checked [here](https://github.com/redhat-cop/infra-ansible/runs/927504765)

### Is there a relevant Issue open for this?
resolves #520 

### Other Relevant info, PRs, etc.
None

### People to notify
cc: @redhat-cop/infra-ansible
