### PR TITLE
RH SSO: Make it possible to add execution config on new, existing/new and existing/update

### DIFF
--- a/roles/config-rh-sso/tasks/manage-auth-flow-executions.yml
+++ b/roles/config-rh-sso/tasks/manage-auth-flow-executions.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: "Initialize the execution config facts"
+  set_fact:
+    execution_config: {}
+
 - name: "Request Red Hat SSO REST API Access Token"
   uri:
     url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/realms/master/protocol/openid-connect/token"
@@ -49,18 +53,15 @@
           Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
         validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
       register: update_out
-    - name: "Add config"
-      uri:
-        url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms/{{ af.realm }}/authentication/executions/{{ (exec_out.location | basename) }}/config"
-        method: POST
-        body:
-          alias: "{{ af_exec.name }}"
-          config: "{{ af_exec.config | default({}) }}"
-        body_format: json
-        status_code: 201
-        headers:
-          Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-        validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
+    - name: "[NEW|POST] Prepare Execution Config to be processed"
+      set_fact:
+        execution_config:
+          url: "executions/{{ (exec_out.location | basename) }}/config"
+          method: POST
+          body:
+            alias: "{{ af_exec.name }}"
+            config: "{{ af_exec.config | default({}) }}"
+          status_code: 201
   when:
     - exec_check[0] is not defined
 
@@ -68,20 +69,43 @@
   block:
     - debug:
         msg: "Execution type: {{ af_exec.provider }} exists in Authentication Flow: {{ af.name }}"
-    - name: "Update Execution Configuration"
-      uri:
-        url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms/{{ af.realm }}/authentication/config/{{ exec_check[0].authenticationConfig }}"
-        method: PUT
-        body:
-          alias: "{{ af_exec.name }}"
-          config: "{{ af_exec.config | default({}) }}"
-        body_format: json
-        status_code: 204
-        headers:
-          Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
-        validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
+    - name: "[UPDATE|PUT] Prepare Execution Config to be processed"
+      set_fact:
+        execution_config:
+          url: "config/{{ exec_check[0].authenticationConfig }}"
+          method: PUT
+          body:
+            alias: "{{ af_exec.name }}"
+            config: "{{ af_exec.config | default({}) }}"
+          status_code: 204
       when:
         - exec_check[0].authenticationConfig is defined
         - exec_check[0].authenticationConfig|trim != ""
+    - name: "[UPDATE|POST] Prepare Execution Config to be processed"
+      set_fact:
+        execution_config:
+          url: "executions/{{ exec_check[0].id }}/config"
+          method: POST
+          body:
+            alias: "{{ af_exec.name }}"
+            config: "{{ af_exec.config | default({}) }}"
+          status_code: 201
+      when:
+        - exec_check[0].authenticationConfig is undefined
+        - exec_check[0].id is defined
+        - exec_check[0].id|trim != ""
   when:
     - exec_check[0] is defined
+
+- name: "Add|Update Execution config"
+  uri:
+    url: "{{ rh_sso_protocol }}://{{ rh_sso_host }}:{{ rh_sso_port }}/auth/admin/realms/{{ af.realm }}/authentication/{{ execution_config.url }}"
+    method: "{{ execution_config.method }}"
+    body: "{{ execution_config.body }}"
+    body_format: json
+    status_code: "{{ execution_config.status_code }}"
+    headers:
+      Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
+    validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
+  when:
+    - execution_config|length > 0


### PR DESCRIPTION
### What does this PR do?
The logic for handling RH SSO authentication execution config was lacking support for the use-case of updating an existing flow with no config. It already supported adding a config to an new flow and updating an existing flow/config, but not adding a config to existing low. 

### How should this be tested?
Run the automation with an inventory that adds config to an existing authentication flow.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible

