### PR TITLE
Fixing acme-host-cert to do proper DNS clean-up

### DIFF
--- a/roles/certs/acme-host-cert/tasks/add-dns-records.yml
+++ b/roles/certs/acme-host-cert/tasks/add-dns-records.yml
@@ -1,13 +1,13 @@
 ---
 
 - block:
-    - name: "Manage dns TXT records to be validated by ACME ({{ dns_state }})"
+    - name: "Add DNS TXT records to be validated by ACME"
       set_fact:
         certificate_dns_entries: "{{ certificate_dns_entries | default([]) +
                                     [{
                                       'type': 'TXT',
                                       'ttl': '30',
-                                      'state': dns_state,
+                                      'state': 'present',
                                       'record': item.0,
                                       'value': item[1][0]
                                     }]
@@ -17,6 +17,19 @@
     - name: "Call 'manage-dns-records' to update DNS server(s)"
       include_role:
         name: "dns/manage-dns-records"
+
+    - name: "Add DNS records to clean-up dict to prepare for clean-up"
+      set_fact:
+        certificate_dns_cleanup: "{{ certificate_dns_cleanup | default([]) +
+                                    [{
+                                      'type': 'TXT',
+                                      'ttl': '30',
+                                      'state': 'absent',
+                                      'record': item.0,
+                                      'value': item[1][0]
+                                    }]
+                                }}"
+      loop: "{{ acme_certificate_output.challenge_data_dns | dictsort }}"
 
     - name: "Wait a time-period before proceeding"
       pause:

--- a/roles/certs/acme-host-cert/tasks/main.yml
+++ b/roles/certs/acme-host-cert/tasks/main.yml
@@ -5,9 +5,7 @@
 
 # Add DNS TXT records for the ACME request
 - block:
-  - import_tasks: "manage-dns-records.yml"
-    vars:
-      dns_state: 'present'
+  - import_tasks: "add-dns-records.yml"
 
   # Ensure target directories exists
   - import_tasks: "create-directories.yml"
@@ -15,9 +13,11 @@
   # Verify ACME / Let's Encrypt request
   - import_tasks: "acme-request.yml"
 
-  # Remove DNS TXT records no longer needed
-  - import_tasks: "manage-dns-records.yml"
-    vars:
-      dns_state: 'absent'
+  # Clean-up of DNS records used earlier
+  # - this should really be a handler, but there are multiple
+  #   missing features in Ansible + some bugs causing a handler
+  #   not to work with a 'notify' on an include_role as well as
+  #   callig 'include_role' within a handler
+  - import_tasks: "rm-dns-records.yml"
   when:
   - acme_certificate_output.changed

--- a/roles/certs/acme-host-cert/tasks/rm-dns-records.yml
+++ b/roles/certs/acme-host-cert/tasks/rm-dns-records.yml
@@ -1,0 +1,10 @@
+---
+
+- name: "LE Cert DNS cleanup"
+  vars:
+    certificate_dns_entries: "{{ certificate_dns_cleanup }}"
+  include_role:
+    name: "dns/manage-dns-records"
+  when:
+    - certificate_dns_cleanup is defined
+


### PR DESCRIPTION
### What does this PR do?
The LE / acme host cert role didn't do a proper clean-up job in all cases whereas the _acme-challenge record(s) would be left behind after a successful run. This PR fixes the DNS clean-up. 

### How should this be tested?
Use the `generate-lets-encrypt-cert.yml` playbook paired with a Route53 type of inventory to generate valid certs. Observe that the `_acme-challenge` TXT records have been removed after a successful run. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
