### PR TITLE
Fixing issue with Route53 DNS role for record with list of values

### DIFF
--- a/roles/dns/manage-dns-records/tasks/route53/process-one-record.yml
+++ b/roles/dns/manage-dns-records/tasks/route53/process-one-record.yml
@@ -1,33 +1,39 @@
 ---
 
+- set_fact:
+    record_value: []
+
 - name: "Apply workaround fix for Route53 TXT records"
   set_fact:
-    record_value: "{{ (item.type == 'TXT') | ternary('\"' + item.value + '\"', item.value) }}"
+    record_value: "{{ record_value + [ (dns_record.type == 'TXT') | ternary('\"' + dns_value + '\"', dns_value) ] }}"
+  loop: "{{ dns_record.value is string | ternary([ dns_record.value ], dns_record.value) }}"
+  loop_control:
+    loop_var: dns_value
   when:
-    - item.value is defined
+    - dns_record.value is defined
 
 - route53:
-    alias: "{{ item.alias | default(omit) }}"
-    alias_evaluate_target_health: "{{ item.alias_evaluate_target_health | default(omit) }}"
+    alias: "{{ dns_record.alias | default(omit) }}"
+    alias_evaluate_target_health: "{{ dns_record.alias_evaluate_target_health | default(omit) }}"
     alias_hosted_zone_id: "{{ dns.1.route53.alias_hosted_zone_id | default(omit) }}"
-    failover: "{{ item.failover | default(omit) }}"
-    health_check: "{{ item.health_check | default(omit) }}"
+    failover: "{{ dns_record.failover | default(omit) }}"
+    health_check: "{{ dns_record.health_check | default(omit) }}"
     hosted_zone_id: "{{ dns.1.route53.hosted_zone_id | default(omit) }}"
-    identifier: "{{ item.identifier | default(omit) }}"
-    overwrite: "{{ item.overwrite | default(omit) }}"
+    identifier: "{{ dns_record.identifier | default(omit) }}"
+    overwrite: "{{ dns_record.overwrite | default(omit) }}"
     private_zone: "{{ dns.1.route53.private_zone | default(omit) }}"
     profile: "{{ dns.1.route53.profile | default(omit) }}"
-    record: "{{ item.record }}"
-    region: "{{ dns.1.route53.region | default(item.region) | default(omit) }}"
+    record: "{{ dns_record.record }}"
+    region: "{{ dns.1.route53.region | default(dns_record.region) | default(omit) }}"
     retry_internal: "{{ dns.1.route53.retry_interval | default(omit) }}"
-    state: "{{ item.state | default('present') }}"
-    ttl: "{{ item.ttl | default(omit) }}"
-    type: "{{ item.type }}"
+    state: "{{ dns_record.state | default('present') }}"
+    ttl: "{{ dns_record.ttl | default(omit) }}"
+    type: "{{ dns_record.type }}"
     validate_certs: "{{ dns.1.route53.validate_certs | default(omit) }}"
     value: '{{ record_value | default(omit) }}'
     vpc_id: "{{ dns.1.route53.vpc_id | default(omit) }}"
-    wait: "{{ dns.1.route53.wait | default(item.wait) | default(omit) }}"
-    wait_timeout: "{{ dns.1.route53.wait_timeout | default(item.wait_timeout) | default(omit) }}"
-    weight: "{{ item.weight | default(omit) }}"
+    wait: "{{ dns.1.route53.wait | default(dns_record.wait) | default(omit) }}"
+    wait_timeout: "{{ dns.1.route53.wait_timeout | default(dns_record.wait_timeout) | default(omit) }}"
+    weight: "{{ dns_record.weight | default(omit) }}"
     zone: "{{ dns.1.dns_domain }}"
 

--- a/roles/dns/manage-dns-records/tasks/route53/process-records.yml
+++ b/roles/dns/manage-dns-records/tasks/route53/process-records.yml
@@ -10,8 +10,9 @@
 
 - name: "Manage Route53 DNS records for view: {{ dns.0.name }}, zone: {{ dns.1.dns_domain }}"
   include_tasks: process-one-record.yml
-  with_items:
-    - "{{ dns.1.entries }}"
+  loop: "{{ dns.1.entries }}"
+  loop_control:
+    loop_var: dns_record
   when:
     - dns.0.name == 'private' or dns.0.name == 'public'
     - dns.1.entries is defined


### PR DESCRIPTION
### What does this PR do?
The Route53 DNS records role didn't handle the list of records correctly in the workaround for TXT records. This PR fixes this issue to make it process both single value records as well as list of values. 

### How should this be tested?
Run Route53 DNS record processing, and supply the following type of records/values:
- TXT record with single value 
- TXT record with list of values
- non-TXT record (e.g.: A, MX, NS, etc.) with single value
- non-TXT record (e.g.: A, MX, NS, etc.) with list of values

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
