### PR TITLE
Adding an infra-ansible docker image to replace the casl-ansible one

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -1,0 +1,35 @@
+FROM quay.io/openshift/origin-ansible:v3.11
+
+USER root
+
+# Update System and install clients
+RUN \
+    yum-config-manager --disable azure-cli; \
+    yum install -y --setopt=tsflags=nodocs \
+      https://repos.fedorapeople.org/repos/openstack/openstack-queens/rdo-release-queens-2.noarch.rpm \
+      http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm; \
+    yum -y install python2-pip; \
+    pip install --upgrade pip; \
+    yum -y install \
+      python-ovirt-engine-sdk4 \
+      python-ceilometerclient \
+      python-cinderclient python-glanceclient \
+      python-heatclient python-neutronclient \
+      python-novaclient python-saharaclient \
+      python-swiftclient python-troveclient \
+      python-openstackclient python-dns \
+      python2-pyOpenSSL python-shade \
+      python-boto3 \
+      python-openstacksdk; \
+    yum clean all; \
+    rm -rf /var/cache/yum; \
+    pip install --upgrade --force-reinstall requests
+
+COPY images/infra-ansible/root /
+
+RUN /usr/local/bin/user_setup
+
+USER ${USER_UID}
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
+CMD [ "/usr/local/bin/run" ]

--- a/images/infra-ansible/README.md
+++ b/images/infra-ansible/README.md
@@ -1,0 +1,126 @@
+Infra Ansible Docker Client
+===========================
+
+Produces a container capable of acting as a client for interacting with hosting infrastructure, such as OpenStack and AWS.
+
+## Setup
+
+The following steps are required to run the docker client.
+
+1. Install docker
+  1. on RHEL/Fedora: ```{yum/dnf} install docker```
+  2. on Windows: [Install Docker for Windows](https://docs.docker.com/windows/step_one/)
+  3. on OSX: [Max OS X](https://docs.docker.com/installation/mac/)
+  4. on all other Operating Systems: [Supported Platforms](https://docs.docker.com/installation/)
+2. Give your user access to run Docker containers (this is only required in Linux/Unix distros)
+```
+groupadd docker
+usermod -a -G docker ${USER}
+systemctl enable docker
+systemctl restart docker
+```
+
+## Running
+
+For OpenStack and AWS specific see the example runs below. For all others use the following generic run example.
+
+```
+docker run -u `id -u` \
+      -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa \
+      -v $HOME/src/:/tmp/src \
+      -e INVENTORY_DIR=/tmp/src/<path-to-your-inventory> \
+      -e PLAYBOOK_FILE=/tmp/src/<path-to-your-playbook> \
+      -t redhat-cop/infra-ansible
+```
+
+... or, to run in interactive mode:
+
+```
+docker run -u `id -u` \
+      -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa \
+      -v $HOME/src/:/tmp/src \
+      -it redhat-cop/infra-ansible /bin/bash
+```
+
+### For OpenStack
+
+A typical run of the image would look like:
+
+```
+docker run -u `id -u` \
+      -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa \
+      -v $HOME/src/:/tmp/src \
+      -v $HOME/.config/openstack/:/opt/app-root/src/.config/openstack/ \
+      -v /etc/pki:/etc/pki \
+      -e INVENTORY_DIR=/tmp/src/<path-to-your-inventory> \
+      -e PLAYBOOK_FILE=/tmp/src/<path-to-your-playbook> \
+      -e OPTS="-e some-extra-var=my-value" \
+      -t redhat-cop/infra-ansible
+```
+
+NOTE: The above commands expects the following inputs:
+* Your ssh key to be mounted in the container at `/opt/app-root/src/.ssh/id_rsa`
+* An link:https://docs.openstack.org/user-guide/common/cli-set-environment-variables-using-openstack-rc.html[OpenStack RC file] to be mounted at `/opt/app-root/src/.config/openstack/opensh.rc`.
+* Your ansible inventories and playbooks repos to live within the same directory, mounted at `/tmp/src`
+* The `/etc/pki` repo has some custom certs needed by the container 
+
+### For AWS
+A typical run of the image would look like:
+
+```
+docker run -u `id -u` \
+      -v $HOME/.ssh:/opt/app-root/src/.ssh \
+      -v $HOME/aws-credentials.csv:/opt/app-root/src/aws-credentials.csv \
+      -v $HOME/src/:/tmp/src \
+      -e INVENTORY_DIR=/tmp/src/<path-to-your-inventory> \
+      -e PLAYBOOK_FILE=/tmp/src/<path-to-your-playbook> \
+      -e OPTS="-e some-extra-var=my-value" \
+      -t redhat-cop/infra-ansible-ansible
+```
+
+The above commands expects the following inputs:
+* Your ssh key (~/.ssh/id_rsa) to be mounted in the container at `/opt/app-root/src/.ssh/id_rsa`
+* Your AWS credentials (in CSV format) is available in your home directory
+* Your ansible inventories and playbooks repos to live within the same directory, mounted at `/tmp/src`
+
+> **Note:** The AWS credentials file can be using the .csv as downloaded from AWS, or a .sh file can be used and will be sourced as-is (make sure the **AWS_SECRET_ACCESS_KEY** and **AWS_ACCESS_KEY_ID** environment variables are exported correctly).
+
+## Building the Image
+
+This image is built and published to docker.io, so there's no reason to build it if you're just wanting to use the latest stable version. However, if you need to build it for development reasons, here's how:
+
+```
+cd ./infra-ansible
+docker build -f images/infra-ansible/Dockerfile -t redhat-cop/infra-ansible .
+```
+
+## Troubleshooting
+
+Below are some of helpful hints for resolving issues experiencing while configuring and running the container
+
+**Issue**
+
+Getting "permission denied" when attempting to run the docker image, e.g. something similar to:
+
+```
+ :
+time="2015-09-01T11:32:36-04:00" level=fatal msg="Get http:///var/run/docker.sock/v1.18/images/json: dial unix /var/run/docker.sock: permission denied. Are you trying to connect to a TLS-enabled daemon without TLS?"
+ :
+FATA[0000] Post http:///var/run/docker.sock/v1.18/containers/create: dial unix /var/run/docker.sock: permission denied. Are you trying to connect to a TLS-enabled daemon without TLS?
+ :
+```
+
+**Resolution #2**
+
+This error indicates the currently logged in user is unable to access the docker socket.
+
+To resolve this issue, create a new *docker* group and add the user to the *docker* group
+
+```
+groupadd docker
+usermod -a -G docker ${USER}
+systemctl enable docker
+systemctl restart docker
+```
+
+Reboot the machine or log out/log in to reload your environment and complete the configurations.

--- a/images/infra-ansible/root/usr/local/bin/aws_keys
+++ b/images/infra-ansible/root/usr/local/bin/aws_keys
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Example CSV file #1:
+# User name,Password,Access key ID,Secret access key,Console login link
+# user,,AKIAJWYSDFSDFPQW5VFA,EqdiwsWYtDFwZNxAcJU+X1mPRtRLQ4Hve,https://example.signin.aws.amazon.com/console
+
+# Example CSV file #2:
+# Access key ID,Secret access key
+# AKIAJWYSDFSDFPQW5VFA,EqdiwsWYtDFwZNxAcJU+X1mPRtRLQ4Hve
+
+# Default files
+# The CSV file is based on AWS specific CSV files
+# The SH file is just a .sh with whatever content the user has - i.e.: the file will be sourced as-is
+CSV_FILE=~/aws-credentials.csv
+SH_FILE=~/aws-credentials.sh
+
+# Array used to determine the information sourced from the CSV file
+declare -A AWS_entries
+AWS_entries[AWS_ACCESS_KEY_ID]="Access key ID"
+AWS_entries[AWS_SECRET_ACCESS_KEY]="Secret access key"
+
+function parse_csv_file()
+{
+  # Don't do anything if the CSV file doesn't exists
+  if [ ! -f ${CSV_FILE} ]
+  then
+    return
+  fi
+
+  # The CSV has a header line (line 1) and a value line (line 2)
+  csv_headers=`head -n 1 ${CSV_FILE} | tr -d '\r\n'`
+  csv_values=`tail -n 1 ${CSV_FILE} | tr -d '\r\n'`
+
+  # Loop through all the AWS entries of interest to find them...
+  for k in "${!AWS_entries[@]}"
+  do 
+    found=0
+
+    # Let's process up to 9 items on a line (9 is a "wild guess" for a max, but seems enough)
+    for i in 1 2 3 4 5 6 7 8 9;
+    do
+      # Extract one-by-one until the one of interest is found
+      extract=`echo $csv_headers | cut -d ',' -f $i`
+      if [[ "${AWS_entries[$k]}" == "${extract}" ]]
+      then
+        found=${i}
+        break;
+      fi
+    done
+
+    # If found, apply it to the current environment
+    if [ ${found} != 0 ]
+    then
+      export ${k}=`echo ${csv_values} | cut -d ',' -f ${found}`
+    fi
+  done
+}
+
+function apply_sh_file()
+{
+  # Don't do anything if the .sh file doesn't exists
+  if [ ! -f ${SH_FILE} ]
+  then
+    return
+  fi
+
+  # Just apply the .sh file as-is
+  source ${SH_FILE}
+}
+
+parse_csv_file
+apply_sh_file

--- a/images/infra-ansible/root/usr/local/bin/entrypoint
+++ b/images/infra-ansible/root/usr/local/bin/entrypoint
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -f ~/aws-credentials.csv ]
+then
+  source /usr/local/bin/aws_keys
+fi
+
+if [ -f ~/.config/openstack/openrc.sh ]
+then
+  source ~/.config/openstack/openrc.sh
+fi
+
+source /usr/local/bin/entrypoint

--- a/images/infra-ansible/root/usr/local/bin/user_setup
+++ b/images/infra-ansible/root/usr/local/bin/user_setup
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p ${HOME}/.ssh
+chown ${USER_UID}:0 ${HOME}/.ssh
+chmod ug+rwx ${HOME}/.ssh
+
+rm $0


### PR DESCRIPTION
### What does this PR do?
This PR replaces https://github.com/redhat-cop/casl-ansible/pull/388 

Per discussion in the team, we have decided to move this to infra-ansible and just leave casl-ansible as-is. This image is the "starting point" for an infra-ansible image that we can evolve to newer versions, etc. as time allows. 

### How should this be tested?
See https://github.com/redhat-cop/casl-ansible/pull/388

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
