### PR TITLE
Role config-ansible-tower: ADD Tower role variable in README.md

### DIFF
--- a/roles/ansible/tower/config-ansible-tower/README.md
+++ b/roles/ansible/tower/config-ansible-tower/README.md
@@ -16,9 +16,9 @@ The variables used to install an Ansible Tower instance are outlined in the tabl
 
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
-|ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
+|ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`.|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
 |ansible_tower_version|Version of Ansible Tower to install|no|'3.3.0-1'|
-|ansible_tower_oc_download_url|Version of oc client to install. If no URL specified the default will be used.|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
+|ansible_tower_oc_download_url|Version of oc client to install.|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
 |ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
 |ansible_tower.install.pg.host|PostgreSQL hostname to listen on|no|nothing ('')|
 |ansible_tower.install.pg.host|PostgreSQL port to listen on|no|nothing ('')|

--- a/roles/ansible/tower/config-ansible-tower/README.md
+++ b/roles/ansible/tower/config-ansible-tower/README.md
@@ -18,6 +18,7 @@ The variables used to install an Ansible Tower instance are outlined in the tabl
 |:---------|:------------|:---------|:---------|
 |ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
 |ansible_tower_version|Version of Ansible Tower to install|no|'3.3.0-1'|
+|ansible_tower_oc_download_url|Version of oc clinet to install. If no URL specified the default will be used.|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
 |ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
 |ansible_tower.install.pg.host|PostgreSQL hostname to listen on|no|nothing ('')|
 |ansible_tower.install.pg.host|PostgreSQL port to listen on|no|nothing ('')|

--- a/roles/ansible/tower/config-ansible-tower/README.md
+++ b/roles/ansible/tower/config-ansible-tower/README.md
@@ -16,9 +16,9 @@ The variables used to install an Ansible Tower instance are outlined in the tabl
 
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
-|ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`.|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
+|ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
 |ansible_tower_version|Version of Ansible Tower to install|no|'3.3.0-1'|
-|ansible_tower_oc_download_url|Version of oc client to install.|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
+|ansible_tower_oc_download_url|Version of oc client to install|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
 |ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
 |ansible_tower.install.pg.host|PostgreSQL hostname to listen on|no|nothing ('')|
 |ansible_tower.install.pg.host|PostgreSQL port to listen on|no|nothing ('')|

--- a/roles/ansible/tower/config-ansible-tower/README.md
+++ b/roles/ansible/tower/config-ansible-tower/README.md
@@ -18,7 +18,7 @@ The variables used to install an Ansible Tower instance are outlined in the tabl
 |:---------|:------------|:---------|:---------|
 |ansible_tower_download_url|URL from which the Tower installer will be downloaded. If different version required, recommended to change `ansible_tower_version`|no|'https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ ansible_tower_version }}.tar.gz'|
 |ansible_tower_version|Version of Ansible Tower to install|no|'3.3.0-1'|
-|ansible_tower_oc_download_url|Version of oc clinet to install. If no URL specified the default will be used.|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
+|ansible_tower_oc_download_url|Version of oc client to install. If no URL specified the default will be used.|no|'https://mirror.openshift.com/pub/openshift-v3/clients/3.10.47/linux/oc.tar.gz'|
 |ansible_tower.admin_password|Admin password for the Ansible Tower install|yes||
 |ansible_tower.install.pg.host|PostgreSQL hostname to listen on|no|nothing ('')|
 |ansible_tower.install.pg.host|PostgreSQL port to listen on|no|nothing ('')|


### PR DESCRIPTION
### What does this PR do?
Amend `config-ansible-tower` role to document a variable `ansible_tower_oc_download_url` that's used for installation of oc client on the Tower instance. This variable is used every time and has a default value specified but is not documented.

### How should this be tested?
Read through the update README.md.

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.
n/a

### People to notify
cc: @redhat-cop/infra-ansible
