### PR TITLE
Fixing issues with infra-ansible image

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -22,8 +22,14 @@ RUN \
       python-boto3 \
       python-openstacksdk; \
     yum clean all; \
-    rm -rf /var/cache/yum; \
-    pip install --upgrade --force-reinstall requests
+    rm -rf /var/cache/yum
+
+RUN \
+    rpm -e --nodeps python-ipaddress PyYAML; \
+    pip install --upgrade --force-reinstall requests; \
+    pip install --upgrade \
+      "cryptography==2.8" \
+      "openstacksdk==0.26.0"
 
 COPY images/infra-ansible/root /
 


### PR DESCRIPTION
### What does this PR do?
The first iteration of the `infra-ansible` container image is failing with the following error in some cases:
```
"To utilize this module, the installed version of the openstacksdk library MUST be >=0.12."
```
... this PR fixes this issue by locking in a few python packages on older versions. This should be addressed by moving to Python3 later.

### How should this be tested?
Run the automation with the infra-ansible image, attempting to use the `openstack` command to manage things like OSP networks, etc. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
