### PR TITLE
Adding trim to Route53 role

### DIFF
--- a/roles/dns/manage-dns-records/tasks/route53/process-records.yml
+++ b/roles/dns/manage-dns-records/tasks/route53/process-records.yml
@@ -5,8 +5,8 @@
     msg: "WARNING: only 'public' and 'private' views are processed for Route53"
   ignore_errors: True
   when:
-    - dns.0.name != 'private'
-    - dns.0.name != 'public'
+    - dns.0.name|trim != 'private'
+    - dns.0.name|trim != 'public'
 
 - name: "Manage Route53 DNS records for view: {{ dns.0.name }}, zone: {{ dns.1.dns_domain }}"
   include_tasks: process-one-record.yml
@@ -14,6 +14,6 @@
   loop_control:
     loop_var: dns_record
   when:
-    - dns.0.name == 'private' or dns.0.name == 'public'
+    - dns.0.name|trim == 'private' or dns.0.name|trim == 'public'
     - dns.1.entries is defined
     - dns.1.route53 is defined


### PR DESCRIPTION
### What does this PR do?
The role for Route53 wasn't very forgiving when the inventory was defined with whitespaces around the keywords public/private. This PR adds some trims to ensure whitespaces are removed. 

### How should this be tested?
Run DNS management of Route53 content

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @tylerauerbeck 
