### PR TITLE
ROLE: Add missing 'length' when comparing list size (manage-aws-user-password)

### DIFF
--- a/roles/identity-management/manage-aws-user-password/tasks/main.yml
+++ b/roles/identity-management/manage-aws-user-password/tasks/main.yml
@@ -10,7 +10,7 @@
         loop_var: user_data
       when:
         - identities.users is defined
-        - identities.users > 0
+        - identities.users|length > 0
         - user_data.user_name is defined
         - user_data.password is defined
         - user_data.password|length > 0


### PR DESCRIPTION
### What does this PR do?
It will fix the error below
```
TASK [identity-management/manage-aws-user-password : Set initial password for AWS user] *************************************
Friday 11 September 2020  08:48:48 -0400 (0:00:00.023)       0:00:38.340 ******
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'identities.users > 0' failed. The error was: Unexpected templating type error occurred on ({% if identities.users > 0 %} True {% else %} False {% endif %}): '>' not supported between instances of 'list' and 'int'\n\nThe error appears to be in '/var/home/pabraham/Project/RH/infra-ansible/roles/identity-management/manage-aws-user-password/tasks/main.yml': line 5, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Set initial password for AWS user\n      ^ here\n"}
```

### How should this be tested?
Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
