### PR TITLE
Fixing network issues with infra-ansible container

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     pip install --upgrade --force-reinstall requests; \
     pip install --upgrade \
       "cryptography==2.8" \
-      "openstacksdk==0.29"
+      "openstacksdk==0.29.0"
 
 COPY images/infra-ansible/root /
 

--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     pip install --upgrade --force-reinstall requests; \
     pip install --upgrade \
       "cryptography==2.8" \
-      "openstacksdk==0.26.0"
+      "openstacksdk==0.29"
 
 COPY images/infra-ansible/root /
 


### PR DESCRIPTION
### What does this PR do?
The `infra-ansible` container wasn't working correctly for creating networks due to the change in Ansible 2.9 (and follow-up change in https://github.com/ansible/ansible/pull/66952). With this change, the minium openstacksdk is >= 0.29. This PR changes the image to use 0.29.*

### How should this be tested?
Run a provisioning of a network in OSP with the playbooks found in `playbooks/osp/`

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
