### PR TITLE
Adding 'jq' and copying infra-anible content into image

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -2,6 +2,8 @@ FROM quay.io/openshift/origin-ansible:v3.11
 
 USER root
 
+ENV WORK_DIR /infra-ansible
+
 # Update System and install clients
 RUN \
     yum-config-manager --disable azure-cli; \
@@ -11,6 +13,7 @@ RUN \
     yum -y install python2-pip; \
     pip install --upgrade pip; \
     yum -y install \
+      jq \
       python-ovirt-engine-sdk4 \
       python-ceilometerclient \
       python-cinderclient python-glanceclient \
@@ -31,11 +34,14 @@ RUN \
       "cryptography==2.8" \
       "openstacksdk==0.29.0"
 
+COPY . ${WORK_DIR}
 COPY images/infra-ansible/root /
 
 RUN /usr/local/bin/user_setup
 
 USER ${USER_UID}
+
+WORKDIR ${WORK_DIR}
 
 ENTRYPOINT [ "/usr/local/bin/ep" ]
 CMD [ "/usr/local/bin/run" ]


### PR DESCRIPTION
### What does this PR do?
Adding `jq` to the infra-ansible container image + copying the ansible content into the container image for easier use. 

### How should this be tested?
Spin up the infra-ansible image and verify that the `jq` command exists + check that the content of `/infra-ansible` is the same as the repo the image was built from.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
