### PR TITLE
Support deletion of keypair + AWS credentials as env variables

### DIFF
--- a/roles/aws/manage-keypairs/README.md
+++ b/roles/aws/manage-keypairs/README.md
@@ -27,6 +27,10 @@ In scenario one, you will only want to private a name and public_key for an item
 |**aws_keypairs.public_key**| Value of the public key to populate the keypair with | no | N/A |
 |**aws_keypairs.key_location**| Path to the location you would like to save your key at. | no |N/A|
 |**aws_keypairs.key_name**| Name of the file that your private key will be saved to | no | N/A |
+|**aws_keypairs.region**| The AWS region to use | no | null |
+|**aws_keypairs.state**| Create or delete keypair | no | present |
+
+>**NOTE:** This role expects your AWS credentials to be provided as either `aws_key` and `aws_secret` variables or as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. Unless the region variable is set in your inventory, the `aws_region` variable will also have to be provided.
 
 Example Playbook
 ----------------
@@ -35,6 +39,26 @@ Example Playbook
 - hosts: aws-provisioner
   roles:
   - aws/manage-keypairs
+```
+Example Inventory
+-----------------
+```
+---
+ec2_key_name: ec2-example-key-1
+ec2_public_key: |
+  ssh-rsa AAAAB3NzaC1....
+aws_keypairs:
+  - name: "{{ ec2_key_name }}"
+    public_key: "{{ ec2_public_key }}"
+    region: ap-northeast-1
+  - name: "{{ ec2_key_name }}"
+    key_location: /tmp
+    key_name: ec2-example-key-2
+    region: ap-northeast-2
+  - name: "{{ ec2_key_name }}"
+    public_key: "{{ ec2_public_key }}"
+    region: us-east-2
+    state: absent
 ```
 
 License

--- a/roles/aws/manage-keypairs/tasks/manage-existing-keys.yml
+++ b/roles/aws/manage-keypairs/tasks/manage-existing-keys.yml
@@ -6,6 +6,7 @@
     ec2_key:
       name: "{{ item.name }}"
       key_material: "{{ item.public_key }}"
-      aws_access_key: "{{ item.access_key | default(aws_key) }}"
-      aws_secret_key: "{{ item.access_secret | default(aws_secret) }}"
+      state: "{{ item.state | default(omit) }}"
+      aws_access_key: "{{ item.access_key | default(aws_key) | default(omit) }}"
+      aws_secret_key: "{{ item.access_secret | default(aws_secret) | default(omit) }}"
       aws_region: "{{ item.region | default(aws_region) }}"

--- a/roles/aws/manage-keypairs/tasks/manage-new-keys.yml
+++ b/roles/aws/manage-keypairs/tasks/manage-new-keys.yml
@@ -20,8 +20,8 @@
     - name: "Create keypair: {{ item.name }}"
       ec2_key:
         name: "{{ item.name }}"
-        aws_access_key: "{{ item.access_key | default(aws_key) }}"
-        aws_secret_key: "{{ item.access_secret | default(aws_secret) }}"
+        aws_access_key: "{{ item.access_key | default(aws_key) | default(omit) }}"
+        aws_secret_key: "{{ item.access_secret | default(aws_secret) | default(omit) }}"
         aws_region: "{{ item.region | default(aws_region) }}"
         force: "{{ item.force | default(false) }}"
       register: ec2_key

--- a/roles/aws/manage-keypairs/tests/inventory/group_vars/all.yml
+++ b/roles/aws/manage-keypairs/tests/inventory/group_vars/all.yml
@@ -7,9 +7,13 @@ aws_secret: "my-secret"
 aws_keypairs:
   - name: user-test
     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+OYTTqEUNkuiSQnz2jDnv3RPP/U8T38qAncHYEo4ZKRG0jsvUZAYK57IJgj5846xYdXxLfujDtyew/MsPT2E6/2Z21ySBQzEHyLJoTGEVq3aLrIVkbLb8D1AHUkBewfdCjP1E9C+er6p063BssDV4xW6r7lDYw7Lw4evDQ1EAsaXC1gyhdcFAIFbNf3giAlG89hf99kgskb60fUz35bhkN1bzIfHMAK2azMyLwF/ZnpU+GHFEKt2NUtAEVhjfbdCAJKq9pCEbBclAsuzptsdsk8Gmz3BkLJaIPXVq6ORU9umDYCNvcHgNCuutNan3FVy1anm39svFe50yMh1Ke9CF user@localhost"
+    region: us-east-1
   - name: user-new
     key_location: /tmp
   - name: user-new-2
     key_location: /tmp
     key_name: my-key-for-project-x
-
+  - name: user-test
+    public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+OYTTqEUNkuiSQnz2jDnv3RPP/U8T38qAncHYEo4ZKRG0jsvUZAYK57IJgj5846xYdXxLfujDtyew/MsPT2E6/2Z21ySBQzEHyLJoTGEVq3aLrIVkbLb8D1AHUkBewfdCjP1E9C+er6p063BssDV4xW6r7lDYw7Lw4evDQ1EAsaXC1gyhdcFAIFbNf3giAlG89hf99kgskb60fUz35bhkN1bzIfHMAK2azMyLwF/ZnpU+GHFEKt2NUtAEVhjfbdCAJKq9pCEbBclAsuzptsdsk8Gmz3BkLJaIPXVq6ORU9umDYCNvcHgNCuutNan3FVy1anm39svFe50yMh1Ke9CF user@localhost"
+    region: us-east-1
+    state: absent


### PR DESCRIPTION
### What does this PR do?
Add support to delete EC2 key pairs and support using the common `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for authentication.

### How should this be tested?
```
ansible-playbook -i roles/aws/manage-keypairs/tests/inventory playbooks/aws/manage-keypairs.yml
```

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
