### PR TITLE
Fixing LB issues with container

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     yum install -y --setopt=tsflags=nodocs \
       https://repos.fedorapeople.org/repos/openstack/openstack-queens/rdo-release-queens-2.noarch.rpm \
       http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm; \
+    yum -y update python-jinja2; \
     yum -y install python2-pip; \
     pip install --upgrade pip; \
     yum -y install \


### PR DESCRIPTION
### What does this PR do?
The ansible role/playbook to populate the HAproxy was failing due to the version of jinja2. This PR updates jinja2 and fixes the issue. 

### How should this be tested?
Run the `manage-lb/lb-vms.yml` playbook.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
