### PR TITLE
Updating Ansible and OSP SDK

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     yum install -y --setopt=tsflags=nodocs \
       https://repos.fedorapeople.org/repos/openstack/openstack-queens/rdo-release-queens-2.noarch.rpm \
       http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm; \
-    yum -y update python-jinja2; \
+    yum -y update ansible python-jinja2; \
     yum -y install python2-pip; \
     pip install --upgrade pip; \
     yum -y install \
@@ -33,7 +33,7 @@ RUN \
     pip install --upgrade --force-reinstall requests; \
     pip install --upgrade \
       "cryptography==2.8" \
-      "openstacksdk==0.29.0"
+      "openstacksdk==0.37.0"
 
 COPY . ${WORK_DIR}
 COPY images/infra-ansible/root /


### PR DESCRIPTION
### What does this PR do?
The latest `infra-ansible` container image has problems with existing instances. Per [this comment](https://github.com/ansible/ansible/issues/63894#issuecomment-546608127), the openstacksdk needs to be version 0.37.0 or newer. 

Also including an update to get the latest Ansible version. 

### How should this be tested?
Run provisioning of an instance and re-run to observe that it won't have any problems with existing instances.  

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
