### PR TITLE
Fixing up VNC server for use with F32 + minor update to ipa-client install

### DIFF
--- a/roles/config-ipa-client/tasks/ipa-install.yml
+++ b/roles/config-ipa-client/tasks/ipa-install.yml
@@ -32,7 +32,10 @@
   - admin_group|trim != ""
 
 - name: "Set up the IPA/IdM client integration"
-  command: 'ipa-client-install -U --automount-location={{ ipa_automount_location }} -p "{{ ipa_username }}" -w "{{ ipa_password }}" --domain="{{ ipa_domain }}" --force-join'
+  command: 'ipa-client-install -U -p "{{ ipa_username }}" -w "{{ ipa_password }}" --domain="{{ ipa_domain }}" --force-join'
+
+- name: "Set up automount for file systems"
+  command: 'ipa-client-automount -U --location {{ ipa_automount_location }}' 
 
 - name: "Workaround for missing sss in nsswitch.conf"
   lineinfile:
@@ -42,16 +45,18 @@
     state: present
   register: automount_line
 
-- name: "Restart sssd if nsswitch.conf was updated"
-  service:
-    name: sssd
-    state: restarted
+- block:
+  - name: "Restart sssd if nsswitch.conf was updated"
+    service:
+      name: sssd
+      state: restarted
+  - name: "Restart autofs if nsswitch.conf was updated"
+    service:
+      name: autofs
+      state: restarted
   when:
   - automount_line.changed
 
-- name: "Restart autofs if nsswitch.conf was updated"
-  service:
-    name: autofs
-    state: restarted
-  when:
-  - automount_line.changed
+- name: "Reboot the host to ensure all changes have been applied correctly"
+  reboot:
+

--- a/roles/config-ipa-client/tasks/ipa-install.yml
+++ b/roles/config-ipa-client/tasks/ipa-install.yml
@@ -35,7 +35,7 @@
   command: 'ipa-client-install -U -p "{{ ipa_username }}" -w "{{ ipa_password }}" --domain="{{ ipa_domain }}" --force-join'
 
 - name: "Set up automount for file systems"
-  command: 'ipa-client-automount -U --location {{ ipa_automount_location }}' 
+  command: 'ipa-client-automount -U --location {{ ipa_automount_location }}'
 
 - name: "Workaround for missing sss in nsswitch.conf"
   lineinfile:

--- a/roles/config-packages/defaults/main.yml
+++ b/roles/config-packages/defaults/main.yml
@@ -2,4 +2,3 @@
 
 yum_preferred: false
 
-

--- a/roles/config-rh-sso/tasks/manage-roles.yml
+++ b/roles/config-rh-sso/tasks/manage-roles.yml
@@ -57,7 +57,7 @@
       register: rh_sso_clients
     - name: "Get Client ID for Client: {{ role_data.clientName }}"
       set_fact:
-        client_id:  "{{ (rh_sso_clients.json | json_query(query))[0] }}"
+        client_id: "{{ (rh_sso_clients.json | json_query(query))[0] }}"
       vars:
         query: "[?clientId=='{{ role_data.clientName }}'].id"
     - name: "Create Client Role: {{ role_data.name }}"

--- a/roles/config-vnc-server/files/SELinuxVNC-pre-v1.11.te
+++ b/roles/config-vnc-server/files/SELinuxVNC-pre-v1.11.te
@@ -1,0 +1,20 @@
+
+module SELinuxVNC 1.0;
+
+require {
+	type user_home_t;
+	type geoclue_t;
+	type init_t;
+	type nfs_t;
+	type unconfined_service_t;
+	class dir search;
+	class file { getattr open read unlink };
+}
+
+#============= geoclue_t ==============
+allow geoclue_t unconfined_service_t:dir search;
+allow geoclue_t unconfined_service_t:file { getattr open read };
+
+#============= init_t ==============
+allow init_t nfs_t:file { open read };
+allow init_t user_home_t:file { open read unlink };

--- a/roles/config-vnc-server/files/SELinuxVNC.te
+++ b/roles/config-vnc-server/files/SELinuxVNC.te
@@ -2,19 +2,12 @@
 module SELinuxVNC 1.0;
 
 require {
-	type user_home_t;
-	type geoclue_t;
-	type init_t;
 	type nfs_t;
-	type unconfined_service_t;
-	class dir search;
-	class file { getattr open read unlink };
+	type vnc_session_t;
+	class dir { add_name search write };
+	class file { create open write };
 }
 
-#============= geoclue_t ==============
-allow geoclue_t unconfined_service_t:dir search;
-allow geoclue_t unconfined_service_t:file { getattr open read };
-
-#============= init_t ==============
-allow init_t nfs_t:file { open read };
-allow init_t user_home_t:file { open read unlink };
+#============= vnc_session_t ==============
+allow vnc_session_t nfs_t:dir { add_name search write };
+allow vnc_session_t nfs_t:file { create open write };

--- a/roles/config-vnc-server/tasks/main.yml
+++ b/roles/config-vnc-server/tasks/main.yml
@@ -1,27 +1,25 @@
 ---
 
 - block:
-  - name: "Prep for VNC server install"
-    import_tasks: prereq.yml
+    - name: "Prep for VNC server install"
+      import_tasks: prereq.yml
 
-  - name: "Gather the information about the package(s) installed"
-    package_facts:
-      manager: "auto"
+    - name: "Gather the information about the package(s) installed"
+      package_facts:
+        manager: "auto"
 
-  - name: "Prepare VNC runtime"
-    import_tasks: vnc-server-common.yml
+    - name: "Prepare VNC runtime"
+      import_tasks: vnc-server-common.yml
 
-  - name: "Install, configure and enable VNC server (pre v1.11 versions)"
-    import_tasks: vnc-server-pre-v1.11.yml
-    when:
-      - "ansible_facts.packages['tigervnc-server'][0].version is version('1.11', '<', true)"
+    - name: "Install, configure and enable VNC server (pre v1.11 versions)"
+      import_tasks: vnc-server-pre-v1.11.yml
+      when:
+        - "ansible_facts.packages['tigervnc-server'][0].version is version('1.11', '<', true)"
 
-  - name: "Install, configure and enable VNC server (latest versions)"
-    import_tasks: vnc-server.yml
-    when:
-      - "ansible_facts.packages['tigervnc-server'][0].version is version('1.11', '>=', true)"
+    - name: "Install, configure and enable VNC server (latest versions)"
+      import_tasks: vnc-server.yml
+      when:
+        - "ansible_facts.packages['tigervnc-server'][0].version is version('1.11', '>=', true)"
   when:
     - vnc_server_install|default(False)
-  
-
 

--- a/roles/config-vnc-server/tasks/main.yml
+++ b/roles/config-vnc-server/tasks/main.yml
@@ -1,12 +1,27 @@
 ---
 
-- name: "Prep for VNC server install"
-  import_tasks: prereq.yml
-  when:
-    - vnc_server_install|default(False)
+- block:
+  - name: "Prep for VNC server install"
+    import_tasks: prereq.yml
 
-- name: "Install, configure and enable VNC server"
-  import_tasks: vnc-server.yml
+  - name: "Gather the information about the package(s) installed"
+    package_facts:
+      manager: "auto"
+
+  - name: "Prepare VNC runtime"
+    import_tasks: vnc-server-common.yml
+
+  - name: "Install, configure and enable VNC server (pre v1.11 versions)"
+    import_tasks: vnc-server-pre-v1.11.yml
+    when:
+      - "ansible_facts.packages['tigervnc-server'][0].version is version('1.11', '<', true)"
+
+  - name: "Install, configure and enable VNC server (latest versions)"
+    import_tasks: vnc-server.yml
+    when:
+      - "ansible_facts.packages['tigervnc-server'][0].version is version('1.11', '>=', true)"
   when:
     - vnc_server_install|default(False)
+  
+
 

--- a/roles/config-vnc-server/tasks/prereq.yml
+++ b/roles/config-vnc-server/tasks/prereq.yml
@@ -1,18 +1,14 @@
 ---
 
-- name: 'Determine required python firewall package'
-  set_fact:
-    python_firewall_package: "python3-firewall"
-  when:
-  - ansible_python_version is match("3.*")
-
 - name: 'Install required packages'
   package:
-    name: '{{ item }}'
+    name:
+      - tigervnc-server
+      - policycoreutils-python-utils
+      - checkpolicy
+      - firewalld
+      - python3-firewall
     state: installed
-  with_items:
-  - firewalld
-  - "{{ python_firewall_package | default('python-firewall') }}"
 
 - name: 'Ensure firewalld is running'
   service:
@@ -20,16 +16,10 @@
     state: started
     enabled: yes
 
-- name: 'Open Firewall for NFS use'
+- name: 'Open Firewall for VNC use'
   firewalld:
-    port: "{{ item }}"
+    service: vnc-server
     permanent: yes
     state: enabled
     immediate: yes
-  with_items:
-  - 5900/tcp
-  - 5901/tcp
-  - 5902/tcp
-  - 5903/tcp
-  - 5904/tcp
-  - 5905/tcp
+

--- a/roles/config-vnc-server/tasks/vnc-server-common.yml
+++ b/roles/config-vnc-server/tasks/vnc-server-common.yml
@@ -1,0 +1,63 @@
+---
+
+- name: "Ensure .vnc dir exists"
+  file:
+    path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc"
+    state: directory
+    owner: "{{ main_user }}"
+
+- name: "Check to see if a VNC password already exists"
+  stat:
+    path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
+  register: passwd_info
+
+- name: "Set a vnc password"
+  shell: "echo {{ vnc_password | default('vncpasswd01') }} | vncpasswd -f > {{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
+  when: passwd_info.stat.exists == False
+
+- name: "Ensure correct ownership of the vnc password file"
+  file:
+    path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
+    owner: "{{ main_user }}"
+    mode: 0600
+
+- name: "Add the xstartup (gnome) configuration to the main user"
+  copy:
+    src: xstartup-gnome
+    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
+    force: no
+    owner: "{{ main_user }}"
+    mode: 0755
+  when:
+    - gnome_install|default(False)
+
+- name: "Add the xstartup (XFCE) configuration to the main user"
+  copy:
+    src: xstartup-xfce
+    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
+    force: no
+    owner: "{{ main_user }}"
+    mode: 0755
+  when:
+    - xfce_install|default(False)
+
+- name: "Add the xstartup (LXDE) configuration to the main user"
+  copy:
+    src: xstartup-lxde
+    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
+    force: no
+    owner: "{{ main_user }}"
+    mode: 0755
+  when:
+    - lxde_install|default(False)
+
+- name: "Add the xstartup (MATE) configuration to the main user"
+  copy:
+    src: xstartup-mate
+    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
+    force: no
+    owner: "{{ main_user }}"
+    mode: 0755
+  when:
+    - mate_install|default(False)
+

--- a/roles/config-vnc-server/tasks/vnc-server-pre-v1.11.yml
+++ b/roles/config-vnc-server/tasks/vnc-server-pre-v1.11.yml
@@ -1,0 +1,40 @@
+---
+
+- name: "Copy SELinux .te file to the host - used to build the module (pre v1.11)"
+  copy:
+    src: SELinuxVNC-pre-v1.11.te
+    dest: /tmp/SELinuxVNC.te
+
+- name: "Build SELinux module (.mod) to allow VNC"
+  command: checkmodule -M -m -o SELinuxVNC.mod /tmp/SELinuxVNC.te
+
+- name: "Build SELinux module (.pp) to allow VNC"
+  command: semodule_package -m SELinuxVNC.mod -o SELinuxVNC.pp
+
+- name: "Load SELinux module to allow VNC"
+  command: semodule -i SELinuxVNC.pp
+
+- name: "Copy VNC service file into place"
+  copy:
+    src: /usr/lib/systemd/system/vncserver@.service
+    dest: "/etc/systemd/system/vncserver-{{ main_user }}@.service"
+    remote_src: True
+
+- name: "Ensure the user config is set for the vnc service"
+  replace:
+    path: "/etc/systemd/system/vncserver-{{ main_user }}@.service"
+    regexp: "{{ item.0 }}"
+    replace: "{{ item.1 }}"
+  with_together:
+    - ['<USER>', '/home/' ]
+    - [ "{{ main_user }}", "{{ vnc_home_dir }}/" ]
+
+- name: "Reload systemctl daemon"
+  command: systemctl daemon-reload
+
+- name: "Enable and start VNC server for user"
+  service:
+    name: "vncserver-{{ main_user }}@:1"
+    enabled: yes
+    state: started
+

--- a/roles/config-vnc-server/tasks/vnc-server.yml
+++ b/roles/config-vnc-server/tasks/vnc-server.yml
@@ -1,93 +1,5 @@
 ---
 
-- name: "Install additional packages for VNC server"
-  package:
-    name: "{{ item }}"
-    state: installed
-  with_items:
-    - tigervnc-server
-    - policycoreutils-python-utils
-    - checkpolicy
-
-- name: "Ensure .vnc dir exists"
-  file:
-    path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc"
-    state: directory
-    owner: "{{ main_user }}"
-
-- name: "Check to see if a VNC password already exists"
-  stat:
-    path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
-  register: passwd_info
-
-- name: "Set a vnc password"
-  shell: "echo {{ vnc_password | default('vncpasswd01') }} | vncpasswd -f > {{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
-  when: passwd_info.stat.exists == False
-
-- name: "Ensure correct ownership of the vnc password file"
-  file:
-    path: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/passwd"
-    owner: "{{ main_user }}"
-    mode: 0600
-
-- name: "Add the xstartup (gnome) configuration to the main user"
-  copy:
-    src: xstartup-gnome
-    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
-    force: no
-    owner: "{{ main_user }}"
-    mode: 0755
-  when:
-    - gnome_install|default(False)
-
-- name: "Add the xstartup (XFCE) configuration to the main user"
-  copy:
-    src: xstartup-xfce
-    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
-    force: no
-    owner: "{{ main_user }}"
-    mode: 0755
-  when:
-    - xfce_install|default(False)
-
-- name: "Add the xstartup (LXDE) configuration to the main user"
-  copy:
-    src: xstartup-lxde
-    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
-    force: no
-    owner: "{{ main_user }}"
-    mode: 0755
-  when:
-    - lxde_install|default(False)
-
-- name: "Add the xstartup (MATE) configuration to the main user"
-  copy:
-    src: xstartup-mate
-    dest: "{{ vnc_home_dir }}/{{ main_user }}/.vnc/xstartup"
-    force: no
-    owner: "{{ main_user }}"
-    mode: 0755
-  when:
-    - mate_install|default(False)
-
-- name: "Copy VNC service file into place"
-  copy:
-    src: /usr/lib/systemd/system/vncserver@.service
-    dest: "/etc/systemd/system/vncserver-{{ main_user }}@.service"
-    remote_src: True
-
-- name: "Ensure the user config is set for the vnc service"
-  replace:
-    path: "/etc/systemd/system/vncserver-{{ main_user }}@.service"
-    regexp: "{{ item.0 }}"
-    replace: "{{ item.1 }}"
-  with_together:
-    - ['<USER>', '/home/' ]
-    - [ "{{ main_user }}", "{{ vnc_home_dir }}/" ]
-
-- name: "Reload systemctl daemon"
-  command: systemctl daemon-reload
-
 - name: "Copy SELinux .te file to the host - used to build the module"
   copy:
     src: SELinuxVNC.te
@@ -102,9 +14,15 @@
 - name: "Load SELinux module to allow VNC"
   command: semodule -i SELinuxVNC.pp
 
+- name: "Ensure the user has been assigned the VNC session"
+  lineinfile:
+    path: "/etc/tigervnc/vncserver.users"
+    regexp: "^:1={{ main_user }}"
+    line: ":1={{ main_user }}"
+
 - name: "Enable and start VNC server for user"
   service:
-    name: "vncserver-{{ main_user }}@:1"
+    name: "vncserver@:1"
     enabled: yes
     state: started
 


### PR DESCRIPTION
### What does this PR do?
The main change of this PR is to support tigervnc-server v1.11 ... the start-up script has changed to process the user profiles differently. This PR now moves the old functionality into a pre-v1.11 functionality and maintains the main path for v1.11 and later. 

Also, this PR makes a small change to the ipa-client role to allow for F32 to work with automount. This change should be backward compatible, so no checks needed fro this.

### How should this be tested?
Run through the bastion playbook to set up both IdM/automount + VNC server. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
