### PR TITLE
ROLE: Support SCM credential in Ansible Tower project

### DIFF
--- a/playbooks/ansible/tower/configure-ansible-tower.yml
+++ b/playbooks/ansible/tower/configure-ansible-tower.yml
@@ -15,9 +15,9 @@
 - hosts: tower-management-host
   roles:
   - role: ansible/tower/manage-settings
-  - role: ansible/tower/manage-projects
   - role: ansible/tower/manage-credential-types
   - role: ansible/tower/manage-credentials
+  - role: ansible/tower/manage-projects
   - role: ansible/tower/manage-inventories
   - role: ansible/tower/manage-job-templates
   - role: ansible/tower/manage-workflow-templates

--- a/roles/ansible/tower/manage-projects/README.md
+++ b/roles/ansible/tower/manage-projects/README.md
@@ -21,6 +21,7 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.projects.scm_type|Type of source control management to use|no|git|
 |ansible_tower.projects.scm_url|URL to the SCM source|no||
 |ansible_tower.projects.scm_branch|SCM branch to use|no|master|
+|ansible_tower.projects.scm_credential_name|SCM credential name to use|no|null|
 |ansible_tower.projects.organization|Name of the organziation to associate this project with|yes||
 
 **_Note:_** Job Template configuration will **only** happen if the `ansible_tower.projects` portion of the dictionary is defined. Likewise, the installation expects this section to be "complete" if specified as it otherwise may error out.
@@ -39,6 +40,7 @@ ansible_tower:
     scm_type: "git"
     scm_url: "https://github.com/redhat-cop/infra-ansible.git"
     scm_branch: "master"
+    scm_credential_name: "my-credential"
     organization: "Default"
 ```
 

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -8,6 +8,23 @@
   with_items:
   - "{{ existing_organizations_output.rest_output }}"
 
+- name: "Get the credential id based on the credential name"
+  block:
+  - name: "Get the credential"
+    rest_get:
+      host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
+      rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+      rest_password: "{{ ansible_tower.admin_password }}"
+      api_uri: "/api/v2/credentials/?name={{ project.scm_credential_name }}"
+    register: r_credential
+  - name: "Set credential_id fact"
+    set_fact:
+      credential_id: "{{ r_credential.rest_output[0].id | int }}"
+    when:
+    - r_credential.rest_output | length > 0
+  when:
+  - project.scm_credential_name is defined
+
 - name: "Load up the project"
   uri:
     url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/projects/"
@@ -26,5 +43,6 @@
 
 - name: "Clear/Update facts"
   set_fact:
+    credential_id: null
     org_id: ''
     processed_projects: "{{ processed_projects + [ { 'name': project.name } ] }}"

--- a/roles/ansible/tower/manage-projects/templates/project.j2
+++ b/roles/ansible/tower/manage-projects/templates/project.j2
@@ -7,7 +7,7 @@
     "scm_branch": "{{ project.scm_branch | default('master') }}",
     "scm_clean": {{ project.scm_clean | default(false) }},
     "scm_delete_on_update": {{ project.scm_delete_on_update | default(false) }},
-    "credential": null,
+    "credential": {{ credential_id | default(None) | to_json }},
     "timeout": 0,
     "organization": {{ org_id }},
     "scm_update_on_launch": false,

--- a/roles/ansible/tower/manage-projects/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/manage-projects/tests/inventory/group_vars/tower.yml
@@ -8,4 +8,5 @@ ansible_tower:
     scm_type: "git"
     scm_url: "https://github.com/redhat-cop/infra-ansible.git"
     scm_branch: "master"
+    scm_credential_name: "my-credential"
     organization: "Default"


### PR DESCRIPTION
### What does this PR do?
Support SCM credential for Ansible Tower project.
This adds `ansible_tower.projects.scm_credential_name` which when set will try to lookup a credential by that name. If the credential is not set, default to `null` (current behavior).

### How should this be tested?
Added test in `tests`

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
