### PR TITLE
Change the order of execution in the RH SSO config role, and some minor fixes

### DIFF
--- a/roles/config-rh-sso/tasks/main.yml
+++ b/roles/config-rh-sso/tasks/main.yml
@@ -25,6 +25,19 @@
     - 'manage-realm'
 
 - include_tasks:
+    file: 'manage-clients.yml'
+    apply:
+      tags:
+        - 'create-clients'
+        - 'manage-clients'
+  loop: "{{ clients | default([]) }}"
+  loop_control:
+    loop_var: client
+  tags:
+    - 'create-clients'
+    - 'manage-clients'
+
+- include_tasks:
     file: 'manage-roles.yml'
     apply:
       tags:
@@ -49,19 +62,6 @@
   tags:
     - 'create-auth-flow'
     - 'manage-auth-flow'
-
-- include_tasks:
-    file: 'manage-clients.yml'
-    apply:
-      tags:
-        - 'create-clients'
-        - 'manage-clients'
-  loop: "{{ clients | default([]) }}"
-  loop_control:
-    loop_var: client
-  tags:
-    - 'create-clients'
-    - 'manage-clients'
 
 - include_tasks:
     file: 'manage-id-provider.yml'

--- a/roles/identity-management/manage-rh-sso-identities/tasks/manage-users.yml
+++ b/roles/identity-management/manage-rh-sso-identities/tasks/manage-users.yml
@@ -26,18 +26,18 @@
     - item.targets is undefined or "rh-sso" in item.targets
     - item.members is defined
     - user_data.user_name in item.members
-    - item.client_name is undefined or item.client_name|trim == ""
+    - item.clientName is undefined or item.clientName|trim == ""
 
 - name: "Get User Client Roles"
   set_fact:
-    user_client_roles: "{{ user_client_roles + [ { 'role': item.name, 'client': item.client_name } ] }}"
+    user_client_roles: "{{ user_client_roles + [ { 'role': item.name, 'client': item.clientName } ] }}"
   loop: "{{ identities.roles }}"
   when:
     - item.targets is undefined or "rh-sso" in item.targets
     - item.members is defined
     - user_data.user_name in item.members
-    - item.client_name is defined
-    - item.client_name|trim != ""
+    - item.clientName is defined
+    - item.clientName|trim != ""
 
 - name: "Get Red Hat SSO Access Token"
   include_tasks: access-token.yml
@@ -103,6 +103,8 @@
       Authorization: "Bearer {{ rh_sso_token.json.access_token }}"
     validate_certs: "{{ rh_sso_ssl_cert_validation | default(omit) }}"
   register: realm_roles
+  when:
+    - user_realm_roles|length > 0
 
 - name: "Get Realm Role IDs"
   set_fact:


### PR DESCRIPTION
### What does this PR do?
Moves client creation before role creation in case the role is a client role. Fixes casing, and ensures that realm role tasks only happen if necessary

### How should this be tested?
Configure a client with client roles in RH SSO

### Is there a relevant Issue open for this?

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/infra-ansible @oybed @tylerauerbeck 
