### PR TITLE
Adding TSIG key parser

### DIFF
--- a/images/infra-ansible/README.md
+++ b/images/infra-ansible/README.md
@@ -97,7 +97,7 @@ docker run -u `id -u` \
       -t quay.io/redhat-cop/infra-ansible
 ```
 
-The paramters are then available as environment variables:
+The parameters are then available as environment variables:
 
 ```
 >  env | grep TSIG

--- a/images/infra-ansible/README.md
+++ b/images/infra-ansible/README.md
@@ -85,7 +85,7 @@ The above commands expects the following inputs:
 
 > **Note:** The AWS credentials file can be using the .csv as downloaded from AWS, or a .sh file can be used and will be sourced as-is (make sure the **AWS_SECRET_ACCESS_KEY** and **AWS_ACCESS_KEY_ID** environment variables are exported correctly).
 
-## Supplying a TSIG key for DNS management with nsupdate
+### Supplying a TSIG key for DNS management with nsupdate
 
 When doing DNS management with nsupdate, the TSIG key information can be sourced from a TSIG file. These parameters will then be available as environment variables, as shown below:
 

--- a/images/infra-ansible/README.md
+++ b/images/infra-ansible/README.md
@@ -85,6 +85,27 @@ The above commands expects the following inputs:
 
 > **Note:** The AWS credentials file can be using the .csv as downloaded from AWS, or a .sh file can be used and will be sourced as-is (make sure the **AWS_SECRET_ACCESS_KEY** and **AWS_ACCESS_KEY_ID** environment variables are exported correctly).
 
+## Supplying a TSIG key for DNS management with nsupdate
+
+When doing DNS management with nsupdate, the TSIG key information can be sourced from a TSIG file. These parameters will then be available as environment variables, as shown below:
+
+```
+docker run -u `id -u` \
+         :
+      -v $HOME/my-tsig-file.key:/opt/app-root/src/tsig.key \
+         :
+      -t quay.io/redhat-cop/infra-ansible
+```
+
+The paramters are then available as environment variables:
+
+```
+>  env | grep TSIG
+TSIG_KEY_SECRET= ...
+TSIG_KEY_NAME= ...
+TSIG_KEY_ALGORITHM= ...
+```
+
 ## Building the Image
 
 This image is built and published to docker.io, so there's no reason to build it if you're just wanting to use the latest stable version. However, if you need to build it for development reasons, here's how:

--- a/images/infra-ansible/root/usr/local/bin/ep
+++ b/images/infra-ansible/root/usr/local/bin/ep
@@ -10,4 +10,9 @@ then
   source ~/.config/openstack/openrc.sh
 fi
 
+if [ -f ~/tsig.key ]
+then
+  source /usr/local/bin/tsig_keys
+fi
+
 source /usr/local/bin/entrypoint

--- a/images/infra-ansible/root/usr/local/bin/tsig_keys
+++ b/images/infra-ansible/root/usr/local/bin/tsig_keys
@@ -18,9 +18,9 @@ function parse_tsig_file()
     return
   fi
 
-  export TSIG_KEY_NAME=`sed -ne 's/key[[:space:]]*\([^[:space:]]*\)[[:space:]]*{/\1/p' $TSIG_FILE` 
-  export TSIG_KEY_ALGORITHM=`sed -ne 's/[[:space:]]*algorithm[[:space:]]*\([^;]*\);/\1/p' $TSIG_FILE`
-  export TSIG_KEY_SECRET=`sed -ne 's/[[:space:]]*secret[[:space:]]*"\([^"]*\)";/\1/p' $TSIG_FILE`
+  export TSIG_KEY_NAME="`sed -ne 's/key[[:space:]]*\([^[:space:]]*\)[[:space:]]*{.*$/\1/p' $TSIG_FILE`"
+  export TSIG_KEY_ALGORITHM="`sed -ne 's/[[:space:]]*algorithm[[:space:]]*\([^;]*\);.*$/\1/p' $TSIG_FILE`"
+  export TSIG_KEY_SECRET="`sed -ne 's/[[:space:]]*secret[[:space:]]*"\([^"]*\)";.*$/\1/p' $TSIG_FILE`"
 }
 
 parse_tsig_file

--- a/images/infra-ansible/root/usr/local/bin/tsig_keys
+++ b/images/infra-ansible/root/usr/local/bin/tsig_keys
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Example TSIG file:
+#
+#   key example.com. { 
+#      algorithm hmac-md5; 
+#      secret "+Cdjlkef9ZTSeixERZ433Q=="; 
+#  };
+
+# Default files
+TSIG_FILE=~/tsig.key
+
+function parse_tsig_file()
+{
+  # Don't do anything if the file doesn't exists
+  if [ ! -f ${TSIG_FILE} ]
+  then
+    return
+  fi
+
+  export TSIG_KEY_NAME=`sed -ne 's/key[[:space:]]*\([^[:space:]]*\)[[:space:]]*{/\1/p' $TSIG_FILE` 
+  export TSIG_KEY_ALGORITHM=`sed -ne 's/[[:space:]]*algorithm[[:space:]]*\([^;]*\);/\1/p' $TSIG_FILE`
+  export TSIG_KEY_SECRET=`sed -ne 's/[[:space:]]*secret[[:space:]]*"\([^"]*\)";/\1/p' $TSIG_FILE`
+}
+
+parse_tsig_file


### PR DESCRIPTION
### What does this PR do?
Adding an optional parameter to running the infra-ansible container which will source a TSIG key file and make environment variables that can be sourced by the running processes. 

### How should this be tested?
Start the [infra-ansible](https://github.com/redhat-cop/infra-ansible/tree/master/images/infra-ansible) container with a valid `~/tsig.key` file supplied. Then run `env | grep TSIG` to see the key values exist in the environment. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
