### PR TITLE
virt-install enhancement

### DIFF
--- a/roles/virt-install/tasks/create_vm.yml
+++ b/roles/virt-install/tasks/create_vm.yml
@@ -13,12 +13,12 @@
 - name: 'Compose Command for new VM provisioning'
   include_tasks: 'virt-install.yml'
   when:
-    - inventory_hostname == hostvars[vm]['infrahost']
-    - hostvars[vm]['libvirt_name'] not in existing_vms.stdout_lines
+    - inventory_hostname == hostvars[instance]['infrahost']
+    - hostvars[instance]['libvirt_name'] not in existing_vms.stdout_lines
   with_items:
     - "{{ groups['infra_vms'] }}"
   loop_control:
-    loop_var: vm
+    loop_var: instance
 
 - name: "Call virt-install to create VMs"
   shell: "{{ item }}"

--- a/roles/virt-install/tasks/virt-install.yml
+++ b/roles/virt-install/tasks/virt-install.yml
@@ -1,30 +1,41 @@
 ---
 
+- name: "Set temporary fact to make referencing below easier"
+  set_fact:
+    vm: "{{ hostvars[instance] }}"
+
 - name: "Populate values for virt install run"
   set_fact:
-    virtinstall_connect: "{{ hostvars[vm]['libvirt_connect'] | default(default_connect) }}"
-    virtinstall_virt_type: "{{ hostvars[vm]['libvirt_virt_type'] | default(default_virt_type) }}"
-    virtinstall_name: "{{ hostvars[vm]['libvirt_name'] | default(default_name) }}"
-    virtinstall_title: "{{ hostvars[vm]['libvirt_title'] | default(default_title) }}"
-    virtinstall_description: "{{ hostvars[vm]['libvirt_description'] | default(default_description) }}"
-    virtinstall_memory: "{{ hostvars[vm]['libvirt_memory'] | default(default_memory) }}"
-    virtinstall_vcpus: "{{ hostvars[vm]['libvirt_vcpus'] | default(default_vcpus) }}"
-    virtinstall_os_variant: "{{ hostvars[vm]['libvirt_os_variant'] | default(default_os_variant) }}"
-    virtinstall_iso: "{{ hostvars[vm]['libvirt_iso'] | default(default_iso) }}"
-    virtinstall_ksfile: "{{ hostvars[vm]['libvirt_ksfile'] | default(default_ksfile) }}"
-    virtinstall_authorized_keys: "{{ hostvars[vm]['libvirt_authorized_keys'] | default(default_authorized_keys) }}"
-    virtinstall_http_host: "{{ hostvars[vm]['libvirt_http_host'] | default(default_http_host) }}"
+    virtinstall_connect: "{{ vm['libvirt_connect'] | default(default_connect) }}"
+    virtinstall_virt_type: "{{ vm['libvirt_virt_type'] | default(default_virt_type) }}"
+    virtinstall_name: "{{ vm['libvirt_name'] | default(default_name) }}"
+    virtinstall_title: "{{ vm['libvirt_title'] | default(default_title) }}"
+    virtinstall_description: "{{ vm['libvirt_description'] | default(default_description) }}"
+    virtinstall_memory: "{{ vm['libvirt_memory'] | default(default_memory) }}"
+    virtinstall_vcpus: "{{ vm['libvirt_vcpus'] | default(default_vcpus) }}"
+    virtinstall_os_variant: "{{ vm['libvirt_os_variant'] | default(default_os_variant) }}"
+    virtinstall_iso: "{{ vm['libvirt_iso'] | default(default_iso) }}"
+    virtinstall_ksfile: "{{ vm['libvirt_ksfile'] | default(default_ksfile) }}"
+    virtinstall_authorized_keys: "{{ vm['libvirt_authorized_keys'] | default(default_authorized_keys) }}"
+    virtinstall_http_host: "{{ vm['libvirt_http_host'] | default(default_http_host) }}"
 
-- name: "Populate network interface if list of NICs is defined"
+- name: "Populate networking info if list of NICs is defined"
   block:
     - set_fact:
         virt_install_network_string: ''
+        extra_args_ip: ''
     - set_fact:
         virt_install_network_string: "{{ virt_install_network_string | default('') + ' --network \"type='+ item['type']|default(default_network_type) + ',source=' + item['hostif']|default(default_network_hostif) + ',source_mode=bridge,model=' + item['model']|default(default_network_model) + '\"' }}"
       with_items:
-        - "{{ hostvars[vm]['libvirt_networks'] }}"
+        - "{{ vm.libvirt_networks }}"
+    - set_fact:
+        extra_args_ip: "ip={{ vm.libvirt_networks[0].ip }}::{{ vm.libvirt_networks[0].gateway }}:{{ vm.libvirt_networks[0].netmask }}:{{ virtinstall_name }}:{{ vm.libvirt_networks[0].name }}:none"
+      when:
+        - vm.libvirt_networks[0].ip is defined
+        - vm.libvirt_networks[0].gateway is defined
+        - vm.libvirt_networks[0].netmask is defined
   when:
-    - hostvars[vm]['libvirt_networks'] is defined
+    - vm.libvirt_networks is defined
 
 - name: "Populate disks if list of disks is defined"
   block:
@@ -33,9 +44,9 @@
     - set_fact:
         virt_install_disk_string: "{{ virt_install_disk_string | default('') + ' --disk pool=' +  item['pool']|default(default_disk_pool) + ',size=' + item['size']|default(default_disk_size) + ',bus=virtio' }}"
       with_items:
-        - "{{ hostvars[vm]['libvirt_disks'] }}"
+        - "{{ vm.libvirt_disks }}"
   when:
-    - hostvars[vm]['libvirt_disks'] is defined
+    - vm.libvirt_disks is defined
 
 - name: "Make KS file available on the target host"
   copy:
@@ -90,7 +101,7 @@
       + ' --vcpus ' + virtinstall_vcpus
       + ' --location http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename
       + ' --initrd-inject=/tmp/' + virtinstall_ksfile | basename
-      + ' --extra-args "inst.repo=http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso] | basename + ' inst.ks=file:/' + virtinstall_ksfile | basename + '"'
+      + ' --extra-args "inst.repo=http://' + virtinstall_http_host + '/' + mounted_iso[virtinstall_iso]|basename + ' inst.ks=file:/' + virtinstall_ksfile|basename + ' ' + extra_args_ip|default('') + '"'
       + ' --graphics spice '
       + ' --video qxl '
       + ' --channel spicevmc '

--- a/roles/virt-install/tests/inventory/host_vars/vm-1.example.com
+++ b/roles/virt-install/tests/inventory/host_vars/vm-1.example.com
@@ -14,11 +14,11 @@ libvirt_networks:
   - name: "eth0"
     type: "bridge"
     hostif: "virbr0"
+    ip: 192.168.1.21
+    netmask: 255.255.255.0
+    gateway: 192.168.1.1
 
 libvirt_disks:
   - name: "disk1"
     size: "20"
 
-eth0_ip: 192.168.1.21
-eth0_mask: 255.255.255.0
-eth0_gw: 192.168.1.1

--- a/roles/virt-install/tests/inventory/host_vars/vm-2.example.com
+++ b/roles/virt-install/tests/inventory/host_vars/vm-2.example.com
@@ -10,13 +10,14 @@ libvirt_ksfile: "{{ inventory_dir }}/../files/vm-2.ks"
 libvirt_http_host: '192.168.1.12'
 
 libvirt_networks:
-  - type: "bridge"
+  - name: "eth0"
+    type: "bridge"
     hostif: "virbr0"
+    ip: 192.168.1.22
+    netmask: 255.255.255.0
+    gateway: 192.168.1.1
 
 libvirt_disks:
   - name: "disk1"
     size: "20"
 
-eth0_ip: 192.168.1.22
-eth0_mask: 255.255.255.0
-eth0_gw: 192.168.1.1

--- a/roles/virt-install/tests/inventory/host_vars/vm-3.example.com
+++ b/roles/virt-install/tests/inventory/host_vars/vm-3.example.com
@@ -11,10 +11,13 @@ libvirt_ksfile: "{{ inventory_dir }}/../files/vm-3.ks"
 libvirt_http_host: '192.168.1.11'
 
 libvirt_networks:
-  - name: "vm-eth0"
+  - name: "eth0"
     type: "bridge"
     hostif: "virbr0"
-  - name: "vm-eth1"
+    ip: "192.168.1.23"
+    netmask: "255.255.255.0"
+    gateway: "192.168.1.1"
+  - name: "eth1"
     hostif: "eth0"
     
 
@@ -24,6 +27,3 @@ libvirt_disks:
   - name: "disk2"
     size: "60"
 
-eth0_ip: 192.168.1.23
-eth0_mask: 255.255.255.0
-eth0_gw: 192.168.1.1


### PR DESCRIPTION
### What does this PR do?
This enhancement helps with environments where DHCP isn't enabled for the VM target network. With this change, the virt-install command will now supply the IP/netmask/gateway, etc. 

### How should this be tested?
Run a virt-install with an inventory that uses static IPs for the VMs

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
