### PR TITLE
Adding functionality to rhsm role to lock in a release

### DIFF
--- a/roles/rhsm/tasks/main.yml
+++ b/roles/rhsm/tasks/main.yml
@@ -42,6 +42,12 @@
         org_id: "{{ rhsm_org_id | default(omit) }}"
         force_register: "{{ rhsm_force_register | default(omit) }}"
 
+    - name: "Lock in specific release - if requested"
+      command: "subscription-manager release --set={{ rhsm_lock_release }}"
+      when:
+        - rhsm_lock_release is defined
+        - rhsm_lock_release|trim != ''
+
     - name: "Obtain currently enabled repos"
       shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
       register: enabled_repos


### PR DESCRIPTION
### What does this PR do?
This change allows the user to lock in a specific release with `subscription-manager` 

### How should this be tested?
Specify `rhsm_lock_release` in the inventory and observe that the release got locked in 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
