### PR TITLE
Add volume mounted SSH keys for Tower on Openshift

### DIFF
--- a/playbooks/ansible/tower/configure-ansible-tower.yml
+++ b/playbooks/ansible/tower/configure-ansible-tower.yml
@@ -2,26 +2,35 @@
 
 - hosts: ansible-tower
   roles:
-  - role: ansible/tower/config-ansible-tower
-  - role: ansible/tower/config-ansible-tower-license
-  - role: ansible/tower/config-ansible-tower-subscription-manifest
-  - role: ansible/tower/config-ansible-tower-ldap
-  - role: config-packages
-  - role: config-pip-packages
-  - role: manage-ssh-private-keys
+    - role: ansible/tower/config-ansible-tower
+    - role: ansible/tower/config-ansible-tower-license
+    - role: ansible/tower/config-ansible-tower-subscription-manifest
+    - role: ansible/tower/config-ansible-tower-ldap
+    - role: config-packages
+    - role: config-pip-packages
+    - role: manage-ssh-private-keys
   tags:
-  - 'never'
-  - 'install'
+    - 'never'
+    - 'install'
+
+- hosts: ansible-tower
+  roles:
+    - role: ansible/tower/config-ansible-tower-ocp
+    - role: ansible/tower/config-ansible-tower-subscription-manifest
+    - role: ansible/tower/config-ansible-tower-ocp-ssh
+  tags:
+    - 'never'
+    - 'install-tower-ocp'
 
 - hosts: tower-management-host
   roles:
-  - role: ansible/tower/manage-settings
-  - role: ansible/tower/manage-credential-types
-  - role: ansible/tower/manage-credentials
-  - role: ansible/tower/manage-projects
-  - role: ansible/tower/manage-inventories
-  - role: ansible/tower/manage-job-templates
-  - role: ansible/tower/manage-workflow-templates
-  - role: ansible/tower/manage-schedules
+    - role: ansible/tower/manage-settings
+    - role: ansible/tower/manage-credential-types
+    - role: ansible/tower/manage-credentials
+    - role: ansible/tower/manage-projects
+    - role: ansible/tower/manage-inventories
+    - role: ansible/tower/manage-job-templates
+    - role: ansible/tower/manage-workflow-templates
+    - role: ansible/tower/manage-schedules
   tags:
-  - 'always'
+    - 'always'

--- a/playbooks/ansible/tower/configure-ansible-tower.yml
+++ b/playbooks/ansible/tower/configure-ansible-tower.yml
@@ -2,35 +2,36 @@
 
 - hosts: ansible-tower
   roles:
-    - role: ansible/tower/config-ansible-tower
-    - role: ansible/tower/config-ansible-tower-license
-    - role: ansible/tower/config-ansible-tower-subscription-manifest
-    - role: ansible/tower/config-ansible-tower-ldap
-    - role: config-packages
-    - role: config-pip-packages
-    - role: manage-ssh-private-keys
+  - role: ansible/tower/config-ansible-tower
+  - role: ansible/tower/config-ansible-tower-license
+  - role: ansible/tower/config-ansible-tower-subscription-manifest
+  - role: ansible/tower/config-ansible-tower-ldap
+  - role: config-packages
+  - role: config-pip-packages
+  - role: manage-ssh-private-keys
   tags:
-    - 'never'
-    - 'install'
+  - 'never'
+  - 'install'
 
 - hosts: ansible-tower
   roles:
-    - role: ansible/tower/config-ansible-tower-ocp
-    - role: ansible/tower/config-ansible-tower-subscription-manifest
-    - role: ansible/tower/config-ansible-tower-ocp-ssh
+  - role: ansible/tower/config-ansible-tower-ocp
+  - role: ansible/tower/config-ansible-tower-subscription-manifest
+  - role: ansible/tower/config-ansible-tower-ocp-ssh
+  - role: ansible/tower/config-ansible-tower-ldap
   tags:
-    - 'never'
-    - 'install-tower-ocp'
+  - 'never'
+  - 'install-tower-ocp'
 
 - hosts: tower-management-host
   roles:
-    - role: ansible/tower/manage-settings
-    - role: ansible/tower/manage-credential-types
-    - role: ansible/tower/manage-credentials
-    - role: ansible/tower/manage-projects
-    - role: ansible/tower/manage-inventories
-    - role: ansible/tower/manage-job-templates
-    - role: ansible/tower/manage-workflow-templates
-    - role: ansible/tower/manage-schedules
+  - role: ansible/tower/manage-settings
+  - role: ansible/tower/manage-credential-types
+  - role: ansible/tower/manage-credentials
+  - role: ansible/tower/manage-projects
+  - role: ansible/tower/manage-inventories
+  - role: ansible/tower/manage-job-templates
+  - role: ansible/tower/manage-workflow-templates
+  - role: ansible/tower/manage-schedules
   tags:
-    - 'always'
+  - 'always'

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
@@ -15,7 +15,7 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
 |ocp_ssh_private_keys.src|File path to ssh private key, for example ssh_private_key.pem|yes||
-|ocp_ssh_private_keys.dest|Path where ssh private key will be mounted on the container|yes|/var/lib/awx/.ssh + src \| basename|
+|ocp_ssh_private_keys.dest|Path where ssh private key will be mounted on the container|no|/var/lib/awx/.ssh + src \| basename|
 |ocp_ssh_private_keys.secret_project|Openshift Project for your tower deployment|no|tower|
 |ocp_ssh_private_keys.secret_name|A name for your secret|no|src \| basename|
 |ocp_ssh_private_keys.deployment_type|One of deployment or deploymentconfig|no|deployment|

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
@@ -16,10 +16,10 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |:---------|:------------|:---------|:---------|
 |ocp_ssh_private_keys.src|File path to ssh private key, for example ssh_private_key.pem|yes||
 |ocp_ssh_private_keys.dest|Path where ssh private key will be mounted on the container|yes|/var/lib/awx/.ssh + src \| basename|
-|ocp_ssh_private_keys.secret_project|Openshift Project for your tower deployment|yes|test-tower|
-|ocp_ssh_private_keys.secret_name|A name for your secret|yes|src \| basename|
+|ocp_ssh_private_keys.secret_project|Openshift Project for your tower deployment|no|tower|
+|ocp_ssh_private_keys.secret_name|A name for your secret|no|src \| basename|
 |ocp_ssh_private_keys.deployment_type|One of deployment or deploymentconfig|no|deployment|
-|ocp_ssh_private_keys.deployment_name|The name of the Ansible Tower deployment|yes|ansible-tower|
+|ocp_ssh_private_keys.deployment_name|The name of the Ansible Tower deployment|no|ansible-tower|
 
 ## Example Inventory
 

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
@@ -1,0 +1,46 @@
+config-ansible-tower-ocp-ssh
+============================
+
+This role is a helper for `config-ansible-tower-ocp` to create an Openshift secret from an SSH key, and mount it as read-only in the `awx` users $HOME/.ssh folder
+
+## Requirements
+
+  - A running OpenShift Cluster and installed 'oc' client in the Ansible host
+
+
+## Role Variables
+
+The variables used to install Ansible Tower on OpenShift are outlined in the table below. 
+
+| Variable | Description | Required | Defaults |
+|:---------|:------------|:---------|:---------|
+|ocp_ssh_private_keys.src|File path to ssh private key, for example ssh_private_key.pem|yes||
+|ocp_ssh_private_keys.dest|Path where ssh private key will be mounted on the container|yes|/var/lib/awx/.ssh + src \| basename|
+|ocp_ssh_private_keys.secret_project|Openshift Project for your tower deployment|yes|test-tower|
+|ocp_ssh_private_keys.secret_name|A name for your secret|yes|src \| basename|
+|ocp_ssh_private_keys.deployment_type|One of deployment or deploymentconfig|no|deployment|
+|ocp_ssh_private_keys.deployment_name|The name of the Ansible Tower deployment|yes|ansible-tower|
+
+## Example Inventory
+
+```yaml
+---
+
+ocp_ssh_private_keys:
+  - src: "{{ inventory_dir }}../files/ssh_private_key.pem"
+    dest: /var/lib/awx/.ssh/ssh_private_key.pem
+    secret_project: "{{ openshift_project }}"
+    secret_name: ssh_private_key
+    deployment_type: deployment
+    deployment_name: ansible-tower
+```
+
+## Example Playbook
+
+```yaml
+---
+
+- hosts: ansible-tower
+  roles:
+  - role: config-ansible-tower-ocp-ssh
+```

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/README.md
@@ -1,7 +1,7 @@
 config-ansible-tower-ocp-ssh
 ============================
 
-This role is a helper for `config-ansible-tower-ocp` to create an Openshift secret from an SSH key, and mount it as read-only in the `awx` users $HOME/.ssh folder
+This role is a helper for `config-ansible-tower-ocp` to create an OpenShift secret from an SSH key, and mount it as read-only in the `awx` users $HOME/.ssh folder
 
 ## Requirements
 

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
@@ -2,4 +2,4 @@
 
 ### OCP SSH Private Keys
 
-openshift_project: test-tower
+openshift_project: tower

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
@@ -1,0 +1,3 @@
+### OCP SSH Private Keys
+
+openshift_project: test-tower

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 ### OCP SSH Private Keys
 
 openshift_project: test-tower

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/defaults/main.yml
@@ -1,5 +1,0 @@
----
-
-### OCP SSH Private Keys
-
-openshift_project: tower

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Add SSH keys to OCP as secrets and mount as volumes
+  include_tasks: ocp-process-ssh-key.yml
+  loop: "{{ ocp_ssh_private_keys }}"
+  loop_control:
+    loop_var: ssh_key
+  when:
+    - ocp_ssh_private_keys is defined
+    - (ocp_ssh_private_keys | type_debug) == 'list'

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
@@ -3,26 +3,27 @@
 - name: Set SSH key filename
   set_fact:
     ssh_key_filename: "{{ ssh_key.src | basename }}"
+    ssh_key_project: "{{ ssh_key.secret_project | default(openshift_project) | default('tower') }}"
 
 - name: Check for existing secret
   command: |
     oc get secret {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
       -o=jsonpath='{.metadata.name}' \
-      -n {{ ssh_key.secret_project }}
+      -n {{ ssh_key_project }}
   register: secret_check
   failed_when: secret_check.rc > 1
 
 - name: Check for existing volume mount
   command: |
     oc set volume {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }} \
-    -n {{ ssh_key.secret_project }}
+    -n {{ ssh_key_project }}
   register: volume_check
 
 - name: Create a generic ssh key secret from file
   command: |
     oc create secret generic {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
       --from-file={{ ssh_key.src }} \
-      -n {{ ssh_key.secret_project }}
+      -n {{ ssh_key_project }}
   when:
     - secret_check.rc != 0
 
@@ -37,6 +38,6 @@
       --mount-path {{ ssh_key.dest | default('/var/lib/awx/.ssh/' + ssh_key_filename) }} \
       --sub-path {{ ssh_key_filename }} \
       --containers ansible-tower-task \
-      -n {{ ssh_key.secret_project }}
+      -n {{ ssh_key_project }}
   when:
     - ssh_key.secret_name not in volume_check.stdout

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
@@ -2,35 +2,37 @@
 
 - name: Check for existing secret
   command: |
-    oc get secret/{{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
-    -n {{ ssh_key.secret_project }} \
-    -o=jsonpath='{.metadata.name}'
-  register: secret_already_exists
-  failed_when: secret_already_exists.rc > 1
+    oc get secret {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
+      -o=jsonpath='{.metadata.name}' \
+      -n {{ ssh_key.secret_project }}
+  register: secret_check
+  failed_when: secret_check.rc > 1
 
 - name: Check for existing volume mount
   command: |
-    oc set volume \
-    -n {{ ssh_key.secret_project }} \
-    {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }}
-  register: volume_already_exists
+    oc set volume {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }} \
+    -n {{ ssh_key.secret_project }}
+  register: volume_check
 
 - name: Create a generic ssh key secret from file
   command: |
     oc create secret generic {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
-    -n {{ ssh_key.secret_project }} \
-    --from-file={{ ssh_key.src }}
+      --from-file={{ ssh_key.src }} \
+      -n {{ ssh_key.secret_project }}
   when:
-    - secret_already_exists.rc != 0
+    - secret_check.rc != 0
 
 - name: Mount generic ssh key secret
   command: |
     oc set volume {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }} \
-    -n {{ ssh_key.secret_project }} \
-    --add --default-mode 0600 --read-only \
-    --type {{ ssh_key.volume_type | default('secret') }} \
-    --mount-path {{ ssh_key.dest }} \
-    --sub-path {{ssh_key.dest | basename }} \
-    --secret-name {{ ssh_key.secret_name | default(ssh_key.dest | basename) }}
+      --add \
+      --default-mode 0600 \
+      --read-only \
+      --secret-name {{ ssh_key.secret_name | default(ssh_key.dest | basename) }} \
+      --type {{ ssh_key.volume_type | default('secret') }} \
+      --mount-path {{ ssh_key.dest }} \
+      --sub-path {{ssh_key.dest | basename }} \
+      --containers ansible-tower-task \
+      -n {{ ssh_key.secret_project }}
   when:
-    - ssh_key.secret_name not in volume_already_exists.stdout
+    - ssh_key.secret_name not in volume_check.stdout

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Check for existing secret 
+  command: |
+    oc get secret/{{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
+      -n {{ ssh_key.secret_project }} \
+      -o=jsonpath='{.metadata.name}'
+  register: secret_already_exists
+  failed_when: secret_already_exists.rc > 1
+
+- name: Check for existing volume mount
+  command: |
+    oc set volume \
+      {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }}
+  register: volume_already_exists
+
+- name: Create a generic ssh key secret from file
+  command: |
+    oc create secret generic {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
+      --from-file={{ ssh_key.src }} \
+      -n {{ ssh_key.secret_project }}
+  when:
+    - secret_already_exists.rc == 1
+
+- name: Mount generic ssh key secret
+  command: |
+    oc set volume {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }} \
+      --add --default-mode 0600 --read-only \
+      --containers ansible-tower-task \
+      --type {{ ssh_key.volume_type | default('secret') }} \
+      --mount-path {{ ssh_key.dest }} \
+      --sub-path {{ssh_key.dest | basename }} \
+      --secret-name {{ ssh_key.secret_name | default(ssh_key.dest | basename) }} \
+      -n {{ ssh_key.secret_project }}
+  when:
+    - ssh_key.secret_name not in volume_already_exists.stdout

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Set SSH key filename
+  set_fact:
+    ssh_key_filename: "{{ ssh_key.src | basename }}"
+
 - name: Check for existing secret
   command: |
     oc get secret {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
@@ -28,10 +32,10 @@
       --add \
       --default-mode 0600 \
       --read-only \
-      --secret-name {{ ssh_key.secret_name | default(ssh_key.dest | basename) }} \
+      --secret-name {{ ssh_key.secret_name | default(ssh_key_filename) }} \
       --type {{ ssh_key.volume_type | default('secret') }} \
-      --mount-path {{ ssh_key.dest }} \
-      --sub-path {{ssh_key.dest | basename }} \
+      --mount-path {{ ssh_key.dest | default('/var/lib/awx/.ssh/' + ssh_key_filename) }} \
+      --sub-path {{ ssh_key_filename }} \
       --containers ansible-tower-task \
       -n {{ ssh_key.secret_project }}
   when:

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Check for existing secret 
+- name: Check for existing secret
   command: |
     oc get secret/{{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
       -n {{ ssh_key.secret_project }} \
@@ -26,7 +26,6 @@
   command: |
     oc set volume {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }} \
       --add --default-mode 0600 --read-only \
-      --containers ansible-tower-task \
       --type {{ ssh_key.volume_type | default('secret') }} \
       --mount-path {{ ssh_key.dest }} \
       --sub-path {{ssh_key.dest | basename }} \

--- a/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ssh/tasks/ocp-process-ssh-key.yml
@@ -3,33 +3,34 @@
 - name: Check for existing secret
   command: |
     oc get secret/{{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
-      -n {{ ssh_key.secret_project }} \
-      -o=jsonpath='{.metadata.name}'
+    -n {{ ssh_key.secret_project }} \
+    -o=jsonpath='{.metadata.name}'
   register: secret_already_exists
   failed_when: secret_already_exists.rc > 1
 
 - name: Check for existing volume mount
   command: |
     oc set volume \
-      {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }}
+    -n {{ ssh_key.secret_project }} \
+    {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }}
   register: volume_already_exists
 
 - name: Create a generic ssh key secret from file
   command: |
     oc create secret generic {{ ssh_key.secret_name | default('ansible-tower-ssh-key') }} \
-      --from-file={{ ssh_key.src }} \
-      -n {{ ssh_key.secret_project }}
+    -n {{ ssh_key.secret_project }} \
+    --from-file={{ ssh_key.src }}
   when:
-    - secret_already_exists.rc == 1
+    - secret_already_exists.rc != 0
 
 - name: Mount generic ssh key secret
   command: |
     oc set volume {{ ssh_key.deployment_type | default('deployment')}}/{{ ssh_key.deployment_name | default('ansible-tower') }} \
-      --add --default-mode 0600 --read-only \
-      --type {{ ssh_key.volume_type | default('secret') }} \
-      --mount-path {{ ssh_key.dest }} \
-      --sub-path {{ssh_key.dest | basename }} \
-      --secret-name {{ ssh_key.secret_name | default(ssh_key.dest | basename) }} \
-      -n {{ ssh_key.secret_project }}
+    -n {{ ssh_key.secret_project }} \
+    --add --default-mode 0600 --read-only \
+    --type {{ ssh_key.volume_type | default('secret') }} \
+    --mount-path {{ ssh_key.dest }} \
+    --sub-path {{ssh_key.dest | basename }} \
+    --secret-name {{ ssh_key.secret_name | default(ssh_key.dest | basename) }}
   when:
     - ssh_key.secret_name not in volume_already_exists.stdout

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_retrieve_token.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_retrieve_token.yml
@@ -4,8 +4,8 @@
     - name: Authenticate with OpenShift via user and password
       shell: |
         oc login {{ openshift_host }} \
-          -u {{ openshift_user }} \
-          -p {{ openshift_password }} \
+          -u '{{ openshift_user }}' \
+          -p '{{ openshift_password }}' \
           --insecure-skip-tls-verify={{ openshift_skip_tls_verify | default(false) | bool }}
       no_log: true
     - name: Retrieve Access Token ...


### PR DESCRIPTION
### What does this PR do?

Adds one or more volume-mounted SSH key to Ansible Tower on Openshift. The basic pattern follows some of the recent work done on the installer using simple `oc` cli commands:

```bash
oc create secret generic ...
oc set volume --type secret --add ...
```
Also would like to add some single quotes to `oc login` commands to allow for use of special characters while crushing any attempts at shell expansion.

### How should this be tested?

Run the playbooks provided in the README against a running ansible-tower deployment and then verify the file permissions  and content are correct:

```bash
oc rsh -c ansible-tower-task <POD_NAME> ls -lah /var/lib/awx/.ssh/
oc rsh -c ansible-tower-task <POD_NAME> cat -lah /var/lib/awx/.ssh/<SSH_KEY_FILE>.pem
```

This was also tested with various combinations of the secret or volume mount being either missing or present to ensure it properly add the file and skip the task if the key is already present.

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
