### PR TITLE
Add container image/tag overrides for using custom Ansible Tower container images

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -46,6 +46,8 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |pg_sslmode|SSL mode to be used in communication between Tower and PostgreSQL|no|prefer|
 |postgress_activate_wait|Time in seconds in which role will wait for PostgreSQL to become available during installation of Tower|no|120|
 |ansible_customization_file|Tower Installer may have some bugs in specific versions, this variable points to archive which holds an overlay if any Installer changes are needed|no|N/A|
+|kubernetes_awx_image|Container repository/image for custom Ansible Tower container images|no|Determined by Ansible Tower installer|
+|kubernetes_awx_version|Container tag for custom Ansible Tower container image|no|Determined by Ansible Tower installer|
 
 ## Example Inventory
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -46,8 +46,7 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |pg_sslmode|SSL mode to be used in communication between Tower and PostgreSQL|no|prefer|
 |postgress_activate_wait|Time in seconds in which role will wait for PostgreSQL to become available during installation of Tower|no|120|
 |ansible_customization_file|Tower Installer may have some bugs in specific versions, this variable points to archive which holds an overlay if any Installer changes are needed|no|N/A|
-|kubernetes_awx_image|Container repository/image for custom Ansible Tower container images|no|Determined by Ansible Tower installer|
-|kubernetes_awx_version|Container tag for custom Ansible Tower container image|no|Determined by Ansible Tower installer|
+|tower_vars_overrides|(Dict) Used to override settings in the Tower Installer group_vars/all file. See "Tower Overrides" below for details.|no||
 
 ## Example Inventory
 
@@ -78,6 +77,20 @@ openshift_password: "XXXXX"
   - role: config-ansible-tower-ocp
 ```
 
+## Tower Overrides
+
+Most variables are set through the included [inventory.j2](templates/inventory.j2) template. However, there are some advanced use cases which require overriding the `group_vars/all` file inside of the bundled Tower installer.
+
+For example, the Ansible Tower documentation recommends adding [custom virtual environments](https://docs.ansible.com/ansible-tower/3.8.1/html/administration/openshift_configuration.html#build-custom-virtual-environments) requires extending the ansible-tower-ocp base image and uploading the container image to your own repository. You can then override the `group_vars/all` file using a dict like the one below:
+
+```yaml
+tower_vars_overrides:
+  kubernetes_awx_image: quay.io/container_repo/container_image
+  kubernetes_awx_version: v3.8.1
+  foo: bar
+```
+
+Note that existing variables will be replaced. New variables introduced such as `foo: bar`, will be appended to the end of the `group_vars/all` file if it does not already exist as a top level variable. Use with caution when replacing variables outside of the documented use cases.
 
 License
 -------

--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -79,7 +79,13 @@ openshift_password: "XXXXX"
 
 ## Tower Overrides
 
-Most variables are set through the included [inventory.j2](templates/inventory.j2) template. However, there are some advanced use cases which require overriding the `group_vars/all` file inside of the bundled Tower installer.
+Variables in the installer playbook are found in several places and may change in future releases of the Tower installer:
+
+- inventory 
+- group_vars/all 
+- roles/kubernetes/defaults/main.yml
+
+Most variables are set through the included [inventory.j2](templates/inventory.j2) template. However, there are some advanced use cases which require overriding the `group_vars/all` file inside of the bundled Tower installer. This role is designed to allow new variables to be set through the inventory using the `tower_vars_overrides` dict.
 
 For example, the Ansible Tower documentation recommends adding [custom virtual environments](https://docs.ansible.com/ansible-tower/3.8.1/html/administration/openshift_configuration.html#build-custom-virtual-environments) requires extending the ansible-tower-ocp base image and uploading the container image to your own repository. You can then override the `group_vars/all` file using a dict like the one below:
 
@@ -90,7 +96,7 @@ tower_vars_overrides:
   foo: bar
 ```
 
-Note that existing variables will be replaced. New variables introduced such as `foo: bar`, will be appended to the end of the `group_vars/all` file if it does not already exist as a top level variable. Use with caution when replacing variables outside of the documented use cases.
+Note that existing variables will be replaced. New variables, such as `foo: bar` in the example above, will be appended to the end of the `group_vars/all` file if it does not already exist as a top level variable. Use with caution when replacing variables outside of the documented use cases.
 
 License
 -------

--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -85,8 +85,8 @@ For example, the Ansible Tower documentation recommends adding [custom virtual e
 
 ```yaml
 tower_vars_overrides:
-  kubernetes_awx_image: quay.io/container_repo/container_image
-  kubernetes_awx_version: v3.8.1
+  kubernetes_awx_image: registry.redhat.io/ansible-tower-38/ansible-tower-rhel7
+  kubernetes_awx_version: 3.8.1
   foo: bar
 ```
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/create_project.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/create_project.yml
@@ -7,5 +7,4 @@
 
 - name: Creating target OCP project
   command: oc new-project {{ openshift_project }}
-  failed_when: false
-  when: getProject.stdout is search("not found")
+  when: getProject.rc != 0

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -26,6 +26,18 @@
   when:
     - ansible_customization_file is defined
 
+- name: "Apply custom container image to Openshift Installer"
+  lineinfile:
+    path: "{{ ansible_tower_dir }}/group_vars/all"
+    regexp: "^kubernetes_awx_image:"
+    line: "kubernetes_awx_image: {{ kubernetes_awx_image }}"
+
+- name: "Apply custom container image tag to Openshift Installer"
+  lineinfile:
+    path: "{{ ansible_tower_dir }}/group_vars/all"
+    regexp: "^kubernetes_awx_version:"
+    line: "kubernetes_awx_version: {{ kubernetes_awx_version }}"
+
 - name: "Run Tower on Openshift installer using access token"
   shell: "./setup_openshift.sh -e openshift_token={{ openshift_token }}"
   args:

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -26,21 +26,15 @@
   when:
     - ansible_customization_file is defined
 
-- name: "Apply custom container image to Openshift Installer"
+- name: "Add or replace group_vars in the Tower Installer"
   lineinfile:
     path: "{{ ansible_tower_dir }}/group_vars/all"
-    regexp: "^kubernetes_awx_image:"
-    line: "kubernetes_awx_image: {{ kubernetes_awx_image }}"
+    regexp: "^{{ item.key }}:.*$"
+    line: "{{ item.key }}: {{ item.value }}"
+  loop: "{{ lookup('dict', tower_vars_overrides) }}"
   when:
-    - kubernetes_awx_image is defined
-
-- name: "Apply custom container image tag to Openshift Installer"
-  lineinfile:
-    path: "{{ ansible_tower_dir }}/group_vars/all"
-    regexp: "^kubernetes_awx_version:"
-    line: "kubernetes_awx_version: {{ kubernetes_awx_version }}"
-  when:
-    - kubernetes_awx_version is defined
+    - tower_vars_overrides is defined
+    - (tower_vars_overrides | type_debug) == 'dict'
 
 - name: "Run Tower on Openshift installer using access token"
   shell: "./setup_openshift.sh -e openshift_token={{ openshift_token }}"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -31,12 +31,16 @@
     path: "{{ ansible_tower_dir }}/group_vars/all"
     regexp: "^kubernetes_awx_image:"
     line: "kubernetes_awx_image: {{ kubernetes_awx_image }}"
+  when:
+    - kubernetes_awx_image is defined
 
 - name: "Apply custom container image tag to Openshift Installer"
   lineinfile:
     path: "{{ ansible_tower_dir }}/group_vars/all"
     regexp: "^kubernetes_awx_version:"
     line: "kubernetes_awx_version: {{ kubernetes_awx_version }}"
+  when:
+    - kubernetes_awx_version is defined
 
 - name: "Run Tower on Openshift installer using access token"
   shell: "./setup_openshift.sh -e openshift_token={{ openshift_token }}"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - import_tasks: precheck.yml
-- import_tasks: opeshift_authenticate.yml
+- import_tasks: openshift_authenticate.yml
 - import_tasks: create_project.yml
 - import_tasks: setup_pvc.yml
 - import_tasks: deploy_tower.yml

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/setup_pvc.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/setup_pvc.yml
@@ -2,7 +2,7 @@
 
 - block:
     - name: Create PVC for Tower PostgreSQL
-      command: echo -n "{{ lookup('template','templates/pvc.j2') }}" | oc apply -n "{{ openshift_project }}" -f -
+      shell: echo -n {{ lookup('template','templates/pvc.j2') | quote }} | oc apply -n "{{ openshift_project }}" -f -
       register: pvcoutput
       failed_when: pvcoutput.rc != 0
 


### PR DESCRIPTION
### What does this PR do?

- Add lineinfile overrides for Ansible Tower container `image:tag`
- Bug fix on conditional for `oc get project` precheck
- Bug fix/typo on config-ansible-tower/ocp/tasks/main.yml
- Update the PVC apply from command to shell module to allow for the pipe `oc apply -f -` to work properly and use Ansible quote filter

### How should this be tested?

Following https://docs.ansible.com/ansible-tower/3.8.1/html/administration/openshift_configuration.html#build-custom-virtual-environments:

- Create a custom image extending the ansible-tower base image
- Push the custom image to an alternate container repository
- Set the proper variables to override group_vars/all

Note the vars have been changed and are not up-to-date with the docs. The following are correct for Tower >= 3.8.1

Example values:

```yaml
kubernetes_awx_image: quay.io/<example_repository>/ansible-tower-ocp-custom
kubernetes_awx_version: v3.8.1
```
I was able to validate that various dependencies were brought into the container and were consumable by Tower:

```bash
(ansible) sh-4.2$ pip freeze | grep -P 'boto|tower'
ansible-tower-cli==3.3.6
boto==2.49.0
boto3==1.9.200
botocore==1.12.253
(ansible) sh-4.2$ rpm -q pandoc
pandoc-1.12.3.1-2.el7.x86_64
```

### People to notify
cc: @redhat-cop/infra-ansible
@oybed 
@jfilipcz 