### PR TITLE
Various Ansible Tower OCP fixes

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -46,6 +46,7 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |pg_sslmode|SSL mode to be used in communication between Tower and PostgreSQL|no|prefer|
 |postgress_activate_wait|Time in seconds in which role will wait for PostgreSQL to become available during installation of Tower|no|120|
 |ansible_customization_file|Tower Installer may have some bugs in specific versions, this variable points to archive which holds an overlay if any Installer changes are needed|no|N/A|
+|ansible_customization_remote_src|Used to indicate if the above ansible_customization_file is a remote src or not|no|false|
 |tower_vars_overrides|(Dict) Used to override settings in the Tower Installer group_vars/all file. See "Tower Overrides" below for details.|no||
 |clean_up|Flag to indicate if the role should perform clean-up at the end|no|'True' - will perform clean-up|
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -47,6 +47,7 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |postgress_activate_wait|Time in seconds in which role will wait for PostgreSQL to become available during installation of Tower|no|120|
 |ansible_customization_file|Tower Installer may have some bugs in specific versions, this variable points to archive which holds an overlay if any Installer changes are needed|no|N/A|
 |tower_vars_overrides|(Dict) Used to override settings in the Tower Installer group_vars/all file. See "Tower Overrides" below for details.|no||
+|clean_up|Flag to indicate if the role should perform clean-up at the end|no|'True' - will perform clean-up|
 
 ## Example Inventory
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Ansible Tower Download and Version Information
 ansible_tower_download_url: "https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-{{ ansible_tower_version }}.tar.gz"
-ansible_tower_version: 3.8.1-1
+ansible_tower_version: 3.8.2-1
 ansible_tower_remote_src: true
 
 # Initial Default Ansible Tower Config

--- a/roles/ansible/tower/config-ansible-tower-ocp/handlers/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "cleanup temp dir"
+  file:
+    path: "{{ ansible_tower_tmp_dir_path }}"
+    state: absent
+  run_once: True
+  when:
+    - clean_up is undefined or clean_up|bool == true

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -34,6 +34,7 @@
   unarchive:
     src: "{{ ansible_customization_file }}"
     dest: "{{ ansible_tower_dir }}/"
+    remote_src: "{{ ansible_customization_remote_src | default(false) }}"
   when:
     - ansible_customization_file is defined
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -1,9 +1,20 @@
 ---
 
+- name: "Create a temporary directory for the Ansible Tower installer"
+  tempfile:
+    state: directory
+    suffix: ansible-tower
+  register: ansible_tower_tmp_dir
+  notify: "cleanup temp dir"
+
+- name: "Store away temporary directory path"
+  set_fact:
+    ansible_tower_tmp_dir_path: "{{ ansible_tower_tmp_dir.path }}"
+
 - name: "Download & Unpack Ansible Tower installer"
   unarchive:
     src: "{{ ansible_tower_download_url }}"
-    dest: "."
+    dest: "{{ ansible_tower_tmp_dir_path }}"
     list_files: true
     remote_src: "{{ ansible_tower_remote_src }}"
     exclude: "inventory"
@@ -11,7 +22,7 @@
 
 - name: "Set installation facts"
   set_fact:
-    ansible_tower_dir: "{{ ansible_tower_download_fact.files.0 }}"
+    ansible_tower_dir: "{{ ansible_tower_tmp_dir_path }}/{{ ansible_tower_download_fact.files.0 }}"
 
 - name: "Set up the Ansible Tower on Openshift Installer inventory"
   template:
@@ -19,7 +30,7 @@
     dest: "{{ ansible_tower_dir }}/inventory"
   register: inventory
 
-- name: "Apply Ansible customization to Tower Installer .. "
+- name: "Apply Ansible customization to Tower Installer"
   unarchive:
     src: "{{ ansible_customization_file }}"
     dest: "{{ ansible_tower_dir }}/"
@@ -27,11 +38,7 @@
     - ansible_customization_file is defined
 
 - name: "Add or replace group_vars in the Tower Installer"
-  lineinfile:
-    path: "{{ ansible_tower_dir }}/group_vars/all"
-    regexp: "^{{ item.key }}:.*$"
-    line: "{{ item.key }}: {{ item.value }}"
-  loop: "{{ lookup('dict', tower_vars_overrides) }}"
+  include_tasks: update_tower_inventory.yml
   when:
     - tower_vars_overrides is defined
     - (tower_vars_overrides | type_debug) == 'dict'
@@ -41,12 +48,3 @@
   args:
     chdir: "{{ ansible_tower_dir }}"
 
-- name: "parsing installation log..."
-  shell: ls -1 setup_container_cluster-* | tail -n 1 | xargs tail -n 1
-  register: in_outcome
-
-- name: "Installation cleanup .."
-  when: in_outcome.stdout.find('failed=0') == -1
-  file:
-    state: absent
-    path: "{{ ansible_tower_dir }}"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
@@ -1,13 +1,19 @@
 ---
 
+- name: Authenticate with OpenShift via user and password
+  shell: |
+    oc login {{ openshift_host }} \
+      -u '{{ openshift_user }}' \
+      -p '{{ openshift_password }}' \
+      --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
+  no_log: true
+  when:
+    - openshift_user is defined
+    - openshift_user|trim != ''
+    - openshift_password is defined
+    - openshift_password|trim != ''
+
 - block:
-    - name: Authenticate with OpenShift via user and password
-      shell: |
-        oc login {{ openshift_host }} \
-          -u '{{ openshift_user }}' \
-          -p '{{ openshift_password }}' \
-          --insecure-skip-tls-verify={{ openshift_skip_tls_verify | default(false) | bool }}
-      no_log: true
     - name: Retrieve Access Token ...
       shell: oc whoami -t
       register: ocwhoami
@@ -17,16 +23,15 @@
         openshift_token: "{{ ocwhoami.stdout }}"
       no_log: true
   when:
-    - openshift_user is defined
-    - openshift_password is defined
     - openshift_token is not defined or openshift_token|trim == ''
 
-- block:
-    - name: Authenticate with Openshift via token
-      shell: |
-        oc login {{ openshift_host }} \
-          --token '{{ openshift_token }}' \
-          --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
-      no_log: true
+- name: Authenticate with Openshift via token
+  shell: |
+    oc login {{ openshift_host }} \
+      --token '{{ openshift_token }}' \
+      --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
+  no_log: true
   when:
-    - openshift_token is defined and openshift_token|trim != ''
+    - openshift_token is defined
+    - openshift_token|trim != ''
+

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/update_tower_inventory.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/update_tower_inventory.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "Add or replace group_vars in the Tower Installer"
+  lineinfile:
+    path: "{{ ansible_tower_dir }}/group_vars/all"
+    regexp: "^{{ item.key }}:.*$"
+    line: "{{ item.key }}: {{ item.value }}"
+  loop: "{{ lookup('dict', tower_vars_overrides) }}"
+


### PR DESCRIPTION
### What does this PR do?
A few fixes and clean-up
- Changed to use a temporary directory to avoid cluttering the playbook area
- Added handlers to perform clean-up at the end
- Moved the functionality to update the tower inventory based on a dict into a separate file to make sure the `when` check works 
- Fixed up user auth for OCP to allow for user/password to undefined
- Fixed up how the OCP token is retrieved, and hence allow for re-use of existing session without specifying user/password/token

### How should this be tested?
Run through the provisioning of Ansible Tower on OCP with the following combinations:
- user/password and no token set
- no user/password but token set
- valid OCP session but no token, user/password specified
... all the above should work/pass.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @paulbarfuss @jfilipcz 
