### PR TITLE
Updated OCP LDAP CA patch to fetch existing data

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/README.md
@@ -1,5 +1,5 @@
 config-ansible-tower-ocp-ldap-ca
-============================
+================================
 
 This role is a helper for `config-ansible-tower-ocp` to create and provision CA certificate secret and ConfigMap which is  used to validate connection with LDAP
 
@@ -11,12 +11,12 @@ This role is a helper for `config-ansible-tower-ocp` to create and provision CA 
 
 ## Role Variables
 
-The variables used to create and deploy CA secret/ConfigMap  Ansible Tower on OpenShift are outlined in the table below. 
+The variables used to create and deploy CA secret/ConfigMap Ansible Tower on OpenShift are outlined in the table below. 
 
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
 |openshift_project|OCP project in which Ansible Tower is deployed|no|'tower'|
-|ansible_tower.ldap.ca_cert| Path to CA pem file to be uploaded to Ansible Tower - file must be named "ldap.pem" |yes||
+|ansible_tower.ldap.ca_cert|Path to CA pem file to be uploaded to Ansible Tower|yes||
 
 ## Example Inventory
 

--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/defaults/main.yml
@@ -1,17 +1,8 @@
 ---
+
 openshift_project: "tower"
+
 secret_volume_patch_data:
-  spec:
-    template:
-      spec:
-        volumes:
-          - name: ansible-tower-application-credentials
-            secret:
-              items:
-                - key: ldap.py
-                  path: ldap.py
-                - key: credentials_py
-                  path: credentials.py
-                - key: environment_sh
-                  path: environment.sh
-              secretName: ansible-tower-secrets
+  key: ldap.py
+  path: ldap.py
+

--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
@@ -38,7 +38,7 @@
 
 - name: Extract the 'ansible-tower-application-credentials' from the existing deployment
   set_fact:
-    existing_volume: 
+    existing_volume:
       "{{ oc_output.stdout |
           from_json |
           json_query(\"[?name=='ansible-tower-application-credentials']\") }}"

--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
@@ -7,14 +7,14 @@
   register: ldap_ca_check
   failed_when: ldap_ca_check.rc > 1
 
-- name: Create and Mount CA cert as configmap
+- name: Create and Mount CA cert as ConfigMap
   block:
-    - name: Create configmap for CA
+    - name: Create ConfigMap for CA
       command: |
         oc create configmap ldap-pem \
           --from-file={{ ansible_tower.ldap.ca_cert }} \
           -n {{ openshift_project }}
-    - name: Mount configmap as volume in /etc/certs directory
+    - name: Mount ConfigMap as volume in /etc/certs directory
       command: |
         oc set volume deployment/ansible-tower \
           --add \
@@ -32,8 +32,33 @@
       --from-file="{{ role_path }}/files/ldap.py" \
       -n {{ openshift_project }}
 
+- name: Fetch existing deployment template volumes
+  command: oc get deployment/ansible-tower -o=jsonpath="{.spec.template.spec.volumes}"
+  register: oc_output
+
+- name: Extract the 'ansible-tower-application-credentials' from the existing deployment
+  set_fact:
+    existing_volume: 
+      "{{ oc_output.stdout |
+          from_json |
+          json_query(\"[?name=='ansible-tower-application-credentials']\") }}"
+
+- name: Append the new entry to the secret volume list
+  set_fact:
+    add_secret:
+      secret:
+        items: "{{ existing_volume[0]['secret']['items'] + [ secret_volume_patch_data ] }}"
+
+- name: Assemble final patch value for the new list
+  set_fact:
+    final_secret_volume_patch:
+      spec:
+        template:
+          spec:
+            volumes: "{{ [ existing_volume | combine(add_secret, recursive=True) ] }}"
+
 - name: Patch Ansible Tower deployment with CA Secret volume
   command: |
     oc patch deployment/ansible-tower \
-      -p '{{ secret_volume_patch_data | to_json }}' \
+      -p '{{ final_secret_volume_patch | to_json }}' \
       -n {{ openshift_project }}


### PR DESCRIPTION
### What does this PR do?
This PR improves the patch strategy for the OCP LDAP CA mechanism to ensure that any existing data is kept as-is, and the additional `ldap.py` is added to the list. 

### How should this be tested?
Run the test with a `ldap.ca_cert` value set, pointing to a valid CA cert

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @jfilipcz 
