### PR TITLE
Aligning Ansible Tower on OCP inventory with standalone Tower inventory

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/README.md
@@ -15,7 +15,7 @@ The variables used to create and deploy CA secret/ConfigMap Ansible Tower on Ope
 
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
-|openshift_project|OCP project in which Ansible Tower is deployed|no|'tower'|
+|ansible_tower.install.openshift.project|OCP project in which Ansible Tower is deployed|no|'tower'|
 |ansible_tower.ldap.ca_cert|Path to CA pem file to be uploaded to Ansible Tower|yes||
 
 ## Example Inventory
@@ -24,8 +24,11 @@ The variables used to create and deploy CA secret/ConfigMap Ansible Tower on Ope
 ---
 
 ansible_tower:
- ldap:
-  - ca_cert: "{{ inventory_dir }}../files/ldap.pem"
+  install:
+    openshift:
+      project: my-tower-project
+  ldap:
+    ca_cert: "{{ inventory_dir }}../files/ldap.pem"
 ```
 
 ## Example Playbook

--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Override default openshift_project if one is supplied
+  set_fact:
+    openshift_project: "{{ ansible_tower.install.openshift.project | d(openshift_project) }}"
+
 - name: Check for CA ConfigMap
   command: |
     oc get configmap ldap-pem \
@@ -33,7 +37,10 @@
       -n {{ openshift_project }}
 
 - name: Fetch existing deployment template volumes
-  command: oc get deployment/ansible-tower -o=jsonpath="{.spec.template.spec.volumes}"
+  command: |
+    oc get deployment/ansible-tower \
+      -n {{ openshift_project }} \
+      -o=jsonpath="{.spec.template.spec.volumes}"
   register: oc_output
 
 - name: Extract the 'ansible-tower-application-credentials' from the existing deployment

--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -1,7 +1,7 @@
 config-ansible-tower-ocp
 ========================
 
-This role is used to deploy and configure an Ansible Tower running as containers in OpenShift. This role is based on the existing Red Hat official sources to deploy Tower in OCP - [ansible-tower-openshift-setup-3.8.1-1](https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-3.8.1-1.tar.gz)
+This role is used to deploy and configure an Ansible Tower running as containers in OpenShift. This role is based on the existing Red Hat official sources to deploy Tower in OCP - [ansible-tower-openshift-setup-latest](https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-latest.tar.gz)
 
 ## Requirements
 
@@ -16,35 +16,38 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 
 **Note:** As Tower Installer is based on Ansible playbooks, you may want to customize specific parts of it. You can copy over specific files by pointing to zip archive which contains new files along with the directory structure.
 
-**Note:** Tower installer supports PostgreSQL deployment done in two way, EmptyDir and PVC based. If you choose EmptyDir (openshift_pg_emptydir=true) be aware that PostgreSQL storage is not going to be persisted in any way. If you choose PVC, and the PVC doesn't exist, this playbook will automatically create a PVC(and underlying PV) based on default configuration of you clusters PV plugin. If PVC does exist, playbook will use it.
+**Note:** Tower installer supports PostgreSQL deployment done in two way, EmptyDir and PVC based. If you choose EmptyDir be aware that PostgreSQL storage is not going to be persisted in any way. If you choose PVC, and the PVC doesn't exist, this playbook will automatically create a PVC(and underlying PV) based on default configuration of you clusters PV plugin. If PVC does exist, playbook will use it.
 
 
 | Variable | Description | Required | Defaults |
 |:---------|:------------|:---------|:---------|
 |ansible_tower_download_url|URL of Ansible Tower installer artifact repository|no|`https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-{{ ansible_tower_version }}.tar.gz`|
-|ansible_tower_version|Version of Ansible Tower Openshift installer|no|3.8.1-1|
+|ansible_tower_version|Version of Ansible Tower Openshift installer|no|latest|
 |ansible_tower_remote_src|Is the Ansible Tower installer fetched from a remote source|no|true|
-|openshift_host|OpenShift API url|no|CRC on local host|
-|openshift_project|Project where to deploy Tower|no|'tower'|
-|openshift_user|User to login into openshift|no|"test"|
-|openshift_password|OpenShift user password|no(either that or token)||
-|openshift_token|OpenShift token|no(either that or password)||
-|openshift_skip_tls_verify| Should installer skip TLS verifcation of Openshift API|no|false|
-|openshift_pg_emptydir|Flag for Postgre to use EmptyDir for storage(not recommended for Production)|no|true|
-|openshift_pg_pvc_name|Persistent Volume Claim to be used for PostgreSQL storage|no|postgresql|
-|openshift_pg_pvc_size|Size of PVC that's going to be created for PostgreSQL storage|no|10Gi|
-|openshift_pg_pvc_wait_retries|How many attempts should have been taken on PVC readiness check|no|5|
-|openshift_pg_pvc_wait_delay|The delay between each attempt on making PVC readiness check (in seconds)|no|30|
-|admin_user|Tower admin username|no|"admin"|
-|admin_password|Tower admin user password|no|"admin"|
-|admin_email|Tower admin user e-mail address|no|root@localhost|
-|secret_key|Tower secret key|no|"abcdefghijkx"|
-|pg_hostname|PostgreSQL hostname to be used with Tower|no|"postgre"|
-|pg_username|PostgreSQL username to be used with Tower|no|"pgu"|
-|pg_database|PostgreSQL database to be used with Tower|no|"tower"|
-|pg_port|PostgreSQL TCP port to be used with Tower|no|5432|
-|pg_sslmode|SSL mode to be used in communication between Tower and PostgreSQL|no|prefer|
-|postgress_activate_wait|Time in seconds in which role will wait for PostgreSQL to become available during installation of Tower|no|120|
+|ansible_tower.install.openshift.host|OpenShift API url|no|CRC on local host|
+|ansible_tower.install.openshift.project|Project where to deploy Tower|no|'tower'|
+|ansible_tower.install.openshift.user|User to login into openshift|no|"test"|
+|ansible_tower.install.openshift.password|OpenShift user password|no(either that or token)||
+|ansible_tower.install.openshift.token|OpenShift token|no(either that or password)||
+|ansible_tower.install.openshift.skip_tls_verify| Should installer skip TLS verifcation of Openshift API|no|false|
+|ansible_tower.install.openshift.pg_emptydir|Flag for PostgreSQL to use EmptyDir for storage(not recommended for Production)|no|true|
+|onsible_tower.install.penshift.pg_pvc_name|Persistent Volume Claim to be used for PostgreSQL storage|no|postgresql|
+|ansible_tower.install.openshift.pg_pvc_size|Size of PVC that's going to be created for PostgreSQL storage|no|10Gi|
+|ansible_tower.install.openshift.pg_pvc_wait_retries|How many attempts should have been taken on PVC readiness check|no|5|
+|ansible_tower.install.openshift.pg_pvc_wait_delay|The delay between each attempt on making PVC readiness check (in seconds)|no|30|
+|ansible_tower.install.secret_key|Tower secret key|no|"abcdefghijkx"|
+|ansible_tower.install.pg.host|PostgreSQL hostname to be used with Tower|no||
+|ansible_tower.install.pg.username|PostgreSQL username to be used with Tower|no|"pgu"|
+|ansible_tower.install.pg.password|PostgreSQL username to be used with Tower|no|"pgu"|
+|ansible_tower.install.pg.database|PostgreSQL database to be used with Tower|no|"tower"|
+|ansible_tower.install.pg.port|PostgreSQL TCP port to be used with Tower|no|5432|
+|ansible_tower.install.pg.sslmode|SSL mode to be used in communication between Tower and PostgreSQL|no|"prefer"|
+|ansible_tower.install.pg.activate_wait|Time in seconds in which role will wait for PostgreSQL to become available during installation of Tower|no|120|
+
+### Advanced Inventory Configuration 
+
+| Variable | Description | Required | Defaults |
+|:---------|:------------|:---------|:---------|
 |ansible_customization_file|Tower Installer may have some bugs in specific versions, this variable points to archive which holds an overlay if any Installer changes are needed|no|N/A|
 |ansible_customization_remote_src|Used to indicate if the above ansible_customization_file is a remote src or not|no|false|
 |tower_vars_overrides|(Dict) Used to override settings in the Tower Installer group_vars/all file. See "Tower Overrides" below for details.|no||
@@ -55,17 +58,16 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 ```yaml
 ---
 
-# Initial Tower Config
-admin_user: 'admin'
-admin_password: 'admin'
-secret_key: 'abcdefghijkx'
-
-# Deploy into OpenShift
-openshift_host: "https://api.crc.testing:6443"
-openshift_skip_tls_verify: "true"
-openshift_project: "test-tower"
-openshift_user: "kubeadmin"
-openshift_password: "XXXXX"
+ansible_tower:
+  admin_password: 'admin'
+  install:
+    secret_key: 'abcdefghijkx'
+    openshift:
+      host: "https://api.crc.testing:6443"
+      project: "test-tower"
+      skip_tls_verify: "true"
+      user: "kubeadmin"
+      password: "XXXXX"
 
 ```
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/defaults/main.yml
@@ -2,13 +2,13 @@
 
 # Ansible Tower Download and Version Information
 ansible_tower_download_url: "https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-{{ ansible_tower_version }}.tar.gz"
-ansible_tower_version: 3.8.2-1
+ansible_tower_version: latest
 ansible_tower_remote_src: true
 
 # Initial Default Ansible Tower Config
 admin_user: 'admin'
 admin_password: 'admin'
-admin_email: 'root@localhost'
+
 secret_key: 'abcdefghijkx'
 
 # Default PostgreSQL setup
@@ -33,4 +33,7 @@ openshift_pg_emptydir: "true"
 # Only applicable if openshift_pg_emptydir is set to "false"
 openshift_pg_pvc_size: "10Gi"
 openshift_pg_pvc_name: "postgresql"
+openshift_pg_pvc_wait_retries: 5
+openshift_pg_pvc_wait_delay: 30
+
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/defaults/main.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/defaults/main.yml
@@ -36,4 +36,3 @@ openshift_pg_pvc_name: "postgresql"
 openshift_pg_pvc_wait_retries: 5
 openshift_pg_pvc_wait_delay: 30
 
-

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
@@ -16,7 +16,7 @@
     openshift_pg_pvc_size: "{{ ansible_tower.install.openshift.pg_pvc_size | d(openshift_pg_pvc_size) }}"
     openshift_pg_pvc_wait_retries: "{{ ansible_tower.install.openshift.pg_pvc_wait_retries | d(openshift_pg_pvc_wait_retries) }}"
     openshift_pg_pvc_wait_delay: "{{ ansible_tower.install.openshift.pg_pvc_wait_delay | d(openshift_pg_pvc_wait_delay) }}"
-    pg_host: "{{ ansible_tower.install.pg.host | d(pg_host) }}" 
+    pg_host: "{{ ansible_tower.install.pg.host | d(pg_host) }}"
     pg_username: "{{ ansible_tower.install.pg.username | d(pg_username) }}"
     pg_password: "{{ ansible_tower.install.pg.password | d(pg_password) }}"
     pg_database: "{{ ansible_tower.install.pg.database | d(pg_database) }}"
@@ -24,7 +24,7 @@
     pg_sslmode: "{{ ansible_tower.install.pg.sslmode | d(pg_sslmode) }}"
     postgress_activate_wait: "{{ ansible_tower.install.pg.activate_wait | d(postgress_activate_wait) }}"
 
-   
+
 - name: Check if inventory file variables are defined
   fail: msg="Please specify the value of {{item}} in your inventory file"
   when: "{{item}} is undefined or {{item}} == ''"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
@@ -1,5 +1,30 @@
 ---
 
+- name: Update values based on passed in inventory
+  set_fact:
+    admin_user: "{{ ansible_tower.admin_user | d(admin_user) }}"
+    admin_password: "{{ ansible_tower.admin_password | d(admin_password) }}"
+    secret_key: "{{ ansible_tower.install.secret_key | d(secret_key) }}"
+    openshift_project: "{{ ansible_tower.install.openshift.project | d(openshift_project) }}"
+    openshift_host: "{{ ansible_tower.install.openshift.host | d(openshift_host) }}"
+    openshift_skip_tls_verify: "{{ ansible_tower.install.openshift.skip_tls_verify | d(openshift_skip_tls_verify) }}"
+    openshift_user: "{{ ansible_tower.install.openshift.user | d(openshift_user) }}"
+    openshfit_password: "{{ ansible_tower.install.openshift.password | d(openshift_password) }}"
+    openshift_token: "{{ ansible_tower.install.openshift.token | d(openshift_token) }}"
+    openshift_pg_emptydir: "{{ ansible_tower.install.openshift.pg_emptydir | d(openshift_pg_emptydir) }}"
+    openshift_pg_pvc_name: "{{ ansible_tower.install.openshift.pg_pvc_name | d(openshift_pg_pvc_name) }}"
+    openshift_pg_pvc_size: "{{ ansible_tower.install.openshift.pg_pvc_size | d(openshift_pg_pvc_size) }}"
+    openshift_pg_pvc_wait_retries: "{{ ansible_tower.install.openshift.pg_pvc_wait_retries | d(openshift_pg_pvc_wait_retries) }}"
+    openshift_pg_pvc_wait_delay: "{{ ansible_tower.install.openshift.pg_pvc_wait_delay | d(openshift_pg_pvc_wait_delay) }}"
+    pg_host: "{{ ansible_tower.install.pg.host | d(pg_host) }}" 
+    pg_username: "{{ ansible_tower.install.pg.username | d(pg_username) }}"
+    pg_password: "{{ ansible_tower.install.pg.password | d(pg_password) }}"
+    pg_database: "{{ ansible_tower.install.pg.database | d(pg_database) }}"
+    pg_port: "{{ ansible_tower.install.pg.port | d(pg_port) }}"
+    pg_sslmode: "{{ ansible_tower.install.pg.sslmode | d(pg_sslmode) }}"
+    postgress_activate_wait: "{{ ansible_tower.install.pg.activate_wait | d(postgress_activate_wait) }}"
+
+   
 - name: Check if inventory file variables are defined
   fail: msg="Please specify the value of {{item}} in your inventory file"
   when: "{{item}} is undefined or {{item}} == ''"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
@@ -16,7 +16,7 @@
     openshift_pg_pvc_size: "{{ ansible_tower.install.openshift.pg_pvc_size | d(openshift_pg_pvc_size) }}"
     openshift_pg_pvc_wait_retries: "{{ ansible_tower.install.openshift.pg_pvc_wait_retries | d(openshift_pg_pvc_wait_retries) }}"
     openshift_pg_pvc_wait_delay: "{{ ansible_tower.install.openshift.pg_pvc_wait_delay | d(openshift_pg_pvc_wait_delay) }}"
-    pg_host: "{{ ansible_tower.install.pg.host | d(pg_host) }}"
+    pg_host: "{{ ansible_tower.install.pg.host | d('') }}"
     pg_username: "{{ ansible_tower.install.pg.username | d(pg_username) }}"
     pg_password: "{{ ansible_tower.install.pg.password | d(pg_password) }}"
     pg_database: "{{ ansible_tower.install.pg.database | d(pg_database) }}"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
@@ -24,7 +24,6 @@
     pg_sslmode: "{{ ansible_tower.install.pg.sslmode | d(pg_sslmode) }}"
     postgress_activate_wait: "{{ ansible_tower.install.pg.activate_wait | d(postgress_activate_wait) }}"
 
-
 - name: Check if inventory file variables are defined
   fail: msg="Please specify the value of {{item}} in your inventory file"
   when: "{{item}} is undefined or {{item}} == ''"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/setup_pvc.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/setup_pvc.yml
@@ -10,8 +10,8 @@
       command: oc get pvc {{ openshift_pg_pvc_name }} -n {{ openshift_project }} -o=jsonpath='{.status.phase}'
       register: pg_pvc_status
       until: pg_pvc_status.stdout is search("Bound")
-      retries: "{{ openshift_pg_pvc_wait_retries | default(5) }}"
-      delay: "{{ openshift_pg_pvc_wait_delay | default(30) }}"
+      retries: "{{ openshift_pg_pvc_wait_retries }}"
+      delay: "{{ openshift_pg_pvc_wait_delay }}"
 
   when:
     - openshift_pg_emptydir|trim == 'false'

--- a/roles/ansible/tower/config-ansible-tower-ocp/templates/inventory.j2
+++ b/roles/ansible/tower/config-ansible-tower-ocp/templates/inventory.j2
@@ -16,7 +16,7 @@ secret_key="{{ secret_key }}"
 
 # Set pg_hostname if you have an external postgres server, otherwise
 # a new postgres service will be created
-# pg_hostname=postgresql
+# pg_hostname="{{ pg_host }}"
 
 # If using an external database, provide your existing credentials.
 # If you choose to use the provided containerized Postgres depolyment, these
@@ -25,8 +25,8 @@ pg_username="{{ pg_username }}"
 pg_password="{{ pg_password }}"
 pg_database="{{ pg_database }}"
 pg_port="{{ pg_port }}"
-pg_sslmode='prefer'  # set to 'verify-full' for client-side enforced SSL
-postgress_activate_wait="{{ postgress_activate_wait}}"
+pg_sslmode="{{ pg_sslmode }}"  # set to 'verify-full' for client-side enforced SSL
+postgress_activate_wait="{{ postgress_activate_wait }}"
 
 # Note: The user running this installer will need cluster-admin privileges.
 # Tower's job execution container requires running in privileged mode,
@@ -37,7 +37,7 @@ postgress_activate_wait="{{ postgress_activate_wait}}"
 
 openshift_host="{{ openshift_host }}"
 openshift_skip_tls_verify="{{ openshift_skip_tls_verify }}"
-openshift_project="{{ openshift_project}}"
+openshift_project="{{ openshift_project }}"
 openshift_user="{{ openshift_user }}"
 openshift_token="{{ openshift_token }}"
 # If you don't want to hardcode a password here, just do:

--- a/roles/ansible/tower/config-ansible-tower-ocp/tests/inventory/group_vars/tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tests/inventory/group_vars/tower.yml
@@ -6,26 +6,26 @@ ansible_connection: local
 #       - please replace with valid values and files
 
 ansible_tower_download_url: "https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-{{ ansible_tower_version }}.tar.gz"
-ansible_tower_version: 3.8.1-1
+ansible_tower_version: 3.8.2-1
+
 
 ##Initial Tower Config
-admin_user: 'admin'
-admin_password: 'admin'
-secret_key: 'abcdefghijkx'
-admin_email: 'root@localhost'
-
-pg_username: 'pgu'
-pg_password: 'pgu'
-pg_database: 'testtower'
-pg_port: '5432'
-pg_sslmode: 'prefer'  # set to 'verify-full' for client-side enforced SSL
-postgress_activate_wait: "120"
-
-# Deploy into Openshift
-
-openshift_host: "https://api.crc.testing:6443"
-openshift_skip_tls_verify: "true"
-openshift_project: "test-tower"
-openshift_user: "kubeadmin"
-openshift_password: "APBEh-jjrVy-hLQZX-VI9Kg"
-openshift_pg_emptydir: "true"
+ansible_tower:
+  admin_user: 'admin'
+  admin_password: 'admin'
+  install:
+    secret_key: 'abcdefghijkx'
+    openshift:
+      host: "https://api.crc.testing:6443"
+      project: "test-tower"
+      skip_tls_verify: "true"
+      user: "kubeadmin"
+      password: "APBEh-jjrVy-hLQZX-VI9Kg"
+      pg_emptydir: "true"
+    pg:
+      username: 'pgu'
+      password: 'pgu'
+      database: 'testtower'
+      port: '5432'
+      sslmode: 'prefer'  # set to 'verify-full' for client-side enforced SSL
+      activate_wait: "120"


### PR DESCRIPTION
### What does this PR do?
Aligning the Ansible Tower install/configure roles to use the `ansible_tower` dict structure for inventory

### How should this be tested?
Use the `ansible_tower` dict, with OpenShift information, to install Ansible Tower on OpenShift

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible @jfilipcz @paulbarfuss 
