### PR TITLE
Add wait after LDAP Secret Patch for rollout to complete

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp-ldap-ca/tasks/ocp_set_ca_certificate.yml
@@ -62,3 +62,12 @@
     oc patch deployment/ansible-tower \
       -p '{{ final_secret_volume_patch | to_json }}' \
       -n {{ openshift_project }}
+
+- name: Verify Ansible Tower deployment has completed rollout after setting CA Secret volume
+  command: |
+    oc rollout status deployment/ansible-tower \
+      -n {{ openshift_project }}
+  register: deployment_status_check
+  until: deployment_status_check.stdout == "deployment \"ansible-tower\" successfully rolled out"
+  retries: 6
+  delay: 10

--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -31,7 +31,7 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |ansible_tower.install.openshift.token|OpenShift token|no(either that or password)||
 |ansible_tower.install.openshift.skip_tls_verify| Should installer skip TLS verifcation of Openshift API|no|false|
 |ansible_tower.install.openshift.pg_emptydir|Flag for PostgreSQL to use EmptyDir for storage(not recommended for Production)|no|true|
-|onsible_tower.install.penshift.pg_pvc_name|Persistent Volume Claim to be used for PostgreSQL storage|no|postgresql|
+|ansible_tower.install.openshift.pg_pvc_name|Persistent Volume Claim to be used for PostgreSQL storage|no|postgresql|
 |ansible_tower.install.openshift.pg_pvc_size|Size of PVC that's going to be created for PostgreSQL storage|no|10Gi|
 |ansible_tower.install.openshift.pg_pvc_wait_retries|How many attempts should have been taken on PVC readiness check|no|5|
 |ansible_tower.install.openshift.pg_pvc_wait_delay|The delay between each attempt on making PVC readiness check (in seconds)|no|30|


### PR DESCRIPTION
### What does this PR do?
This will confirm the rollout has been successful to help avoid a race condition when fetching organizations during the manage-credential or similar phases of the deployment when it expects an org_id from your LDAP provider.

### How should this be tested?
Needs a full end-2-end deployment on Openshfit with LDAP configuration and dependent organizations to see the bug and verify it is fixed.

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
