### PR TITLE
Fix string/bool type mismatch on pg_emptydir check

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/precheck.yml
@@ -9,7 +9,7 @@
     openshift_host: "{{ ansible_tower.install.openshift.host | d(openshift_host) }}"
     openshift_skip_tls_verify: "{{ ansible_tower.install.openshift.skip_tls_verify | d(openshift_skip_tls_verify) }}"
     openshift_user: "{{ ansible_tower.install.openshift.user | d(openshift_user) }}"
-    openshfit_password: "{{ ansible_tower.install.openshift.password | d(openshift_password) }}"
+    openshift_password: "{{ ansible_tower.install.openshift.password | d(openshift_password) }}"
     openshift_token: "{{ ansible_tower.install.openshift.token | d(openshift_token) }}"
     openshift_pg_emptydir: "{{ ansible_tower.install.openshift.pg_emptydir | d(openshift_pg_emptydir) }}"
     openshift_pg_pvc_name: "{{ ansible_tower.install.openshift.pg_pvc_name | d(openshift_pg_pvc_name) }}"

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/setup_pvc.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/setup_pvc.yml
@@ -14,4 +14,4 @@
       delay: "{{ openshift_pg_pvc_wait_delay }}"
 
   when:
-    - openshift_pg_emptydir|trim == 'false'
+    - openshift_pg_emptydir is false


### PR DESCRIPTION
### What does this PR do?
- Small typo fix in the tower-ocp precheck
- Match types on the conditional for the Tower PostgreSQL emptydir/pvc check
### How should this be tested?
Output of some type debugging after having check inexplicably fail:

```
TASK [Debug emptydir without trim] ***********************************************************************************************************************************
Monday 05 April 2021  22:24:58 -0400 (0:00:00.041)       0:00:00.056 ********** 
ok: [localhost] => 
  msg: 'openshift_pg_emptydir is type: bool'

TASK [Debug emptydir with trim] **************************************************************************************************************************************
Monday 05 April 2021  22:24:58 -0400 (0:00:00.041)       0:00:00.097 ********** 
ok: [localhost] => 
  msg: 'openshift_pg_emptydir|trim is type: str'
```
There are definitely some type conversions happening under the covers causing this to fail as can be seen in the output above.

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
