### PR TITLE
Quay Prototype support

### DIFF
--- a/roles/scm/quay/README.md
+++ b/roles/scm/quay/README.md
@@ -9,6 +9,7 @@ Support is available for managing the following assets:
     * Repositories
     * Teams
     * Robot Accounts
+    * Default Permissions (Prototypes)
 
 Requirements
 ------------

--- a/roles/scm/quay/tasks/manage_organization.yml
+++ b/roles/scm/quay/tasks/manage_organization.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Check if Organization Exists
   uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
@@ -11,14 +10,13 @@
       Authorization: "{{ auth_header }}"
   register: quay_organization_exists
 
-
 - name: Create Quay Organization
   uri:
     url: "{{ quay_api_base }}/organization/"
     method: POST
     body:
       name: "{{ quay_organization.name }}"
-      email: "{{ quay_organization.email | default('') }}"
+      email: "{{ quay_organization.email | default(omit) }}"
     validate_certs: "{{ quay_validate_certs }}"
     body_format: json
     status_code: 201
@@ -32,7 +30,7 @@
     method: PUT
     body:
       name: "{{ quay_organization.name }}"
-      email: "{{ quay_organization.email | default('') }}"
+      email: "{{ quay_organization.email | default(omit) }}"
     validate_certs: "{{ quay_validate_certs }}"
     body_format: json
     status_code: 200
@@ -58,6 +56,16 @@
       Authorization: "{{ auth_header }}"
   register: org_robots
 
+- name: List Organization Prototypes
+  uri:
+    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes"
+    validate_certs: "{{ quay_validate_certs }}"
+    status_code:
+      - 200
+    headers:
+      Authorization: "{{ auth_header }}"
+  register: org_prototypes
+
 - name: Manage Robots
   include_tasks: manage_robot.yml
   loop: "{{ quay_organization.robots | default([]) }}"
@@ -70,6 +78,12 @@
   loop_control:
     loop_var: quay_team
 
+- name: Manage Prototypes
+  include_tasks: manage_prototypes.yml
+  loop: "{{ quay_organization.prototypes | default([]) }}"
+  loop_control:
+    loop_var: quay_prototype
+
 - name: List Repositories
   uri:
     url: "{{ quay_api_base }}/repository?namespace={{ quay_organization.name }}"
@@ -81,7 +95,6 @@
     headers:
       Authorization: "{{ auth_header }}"
   register: org_repositories
-
 
 - name: Manage Repositories
   include_tasks: manage_repository.yml
@@ -133,4 +146,3 @@
       when: "item.key not in quay_organization.teams |  map(attribute='name') | list"
 
   when: quay_prune|bool
-

--- a/roles/scm/quay/tasks/manage_prototypes.yml
+++ b/roles/scm/quay/tasks/manage_prototypes.yml
@@ -1,0 +1,66 @@
+---
+- name: Locate Existing Delegate Prototype Matches
+  set_fact:
+    matched_prototypes: "{{ org_prototypes.json.prototypes | \
+      selectattr('delegate.is_robot','equalto',true if quay_prototype.delegate.kind == 'robot' else false) | \
+      selectattr('delegate.kind','equalto','user' if quay_prototype.delegate.kind != 'team' else quay_prototype.delegate.kind) | \
+      selectattr('delegate.name','equalto',quay_organization.name + '+' + quay_prototype.delegate.name if quay_prototype.delegate.kind == 'robot' else quay_prototype.delegate.name) | \
+      list }}"
+
+- name: Locate Existing Activator Prototype Matches
+  set_fact:
+    matched_prototypes: "{{ matched_prototypes | default([]) | \
+      selectattr('activating_user', 'defined') | \
+      rejectattr('activating_user', 'none') | \
+      selectattr('activating_user.is_robot','equalto',true if quay_prototype.activator.kind == 'robot' else false) | \
+      selectattr('activating_user.kind','equalto','user' if quay_prototype.activator.kind != 'team' else quay_prototype.activator.kind) | \
+      selectattr('activating_user.name','equalto',quay_organization.name + '+' + quay_prototype.activator.name if quay_prototype.activator.kind == 'robot' else quay_prototype.activator.name) | \
+      list }}"
+  when: "{{ 'activator' in quay_prototype and quay_prototype.activator is not none }}"
+
+- name: Create Base Prototype Fact
+  set_fact:
+    prototype:
+      role: "{{ quay_prototype.role }}"
+      delegate:
+        kind: "{{ 'user' if quay_prototype.delegate.kind != 'team' else quay_prototype.delegate.kind }}"
+        name: "{{ quay_organization.name + '+' + quay_prototype.delegate.name if quay_prototype.delegate.kind == 'robot' else quay_prototype.delegate.name }}"
+        is_robot: "{{ true if quay_prototype.delegate.kind == 'robot' else false }}"
+
+- name: Create Prototype Activator Fact
+  set_fact:
+    prototype_assigner:
+      role: "{{ quay_prototype.role }}"
+      activating_user:
+        kind: "{{ 'user' if quay_prototype.activator.kind != 'team' else quay_prototype.activator.kind }}"
+        name: "{{ quay_organization.name + '+' + quay_prototype.activator.name if quay_prototype.activator.kind == 'robot' else quay_prototype.activator.name }}"
+        is_robot: "{{ true if quay_prototype.activator.kind == 'robot' else false }}"
+  when: "{{ 'activator' in quay_prototype and quay_prototype.activator is not none }}"
+
+- name: Create Final Prototype Fact
+  set_fact:
+    prototype: "{{ prototype | combine(prototype_assigner | default({}), recursive=true) }}"
+
+- name: Create Prototype
+  uri:
+    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes"
+    method: POST
+    body: "{{ prototype }}"
+    validate_certs: "{{ quay_validate_certs }}"
+    body_format: json
+    status_code: 200
+    headers:
+      Authorization: "{{ auth_header }}"
+  when: matched_prototypes | length == 0
+
+- name: Update Prototype
+  uri:
+    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes/{{ matched_prototypes[0].id }}"
+    method: PUT
+    body: "{{ prototype }}"
+    validate_certs: "{{ quay_validate_certs }}"
+    body_format: json
+    status_code: 200
+    headers:
+      Authorization: "{{ auth_header }}"
+  when: matched_prototypes | length == 1


### PR DESCRIPTION
### What does this PR do?
Support for default permissions for Quay role

### How should this be tested?
The following is a definition that can be applied

```
orgs:
  - name: redhat-cop
    prototypes:
        delegate:
          kind: team
          name: owners
```


### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
No

### People to notify
cc: @redhat-cop/infra-ansible
