### PR TITLE
Fix kustomize permissions in infra-ansible Dockerfile

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 
 RUN curl -fsSL -o kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
     tar -xzf kustomize.tar.gz && \
-    chmod 700 kustomize && \
+    chmod 755 kustomize && \
     cp kustomize /usr/bin/; \
     rm -f kustomize.tar.gz
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the permissions of kustomize within infra-ansible docker image. (700 -> 755)

### How should this be tested?
N/A

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A
### People to notify
cc: @redhat-cop/infra-ansible
