### PR TITLE
config-ansible-ocp: Added missing option to skip TLS verification on one of OC calls

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
@@ -15,7 +15,9 @@
 
 - block:
     - name: Retrieve Access Token ...
-      shell: oc whoami -t
+      shell: | 
+         oc whoami -t \\ 
+         --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
       register: ocwhoami
       no_log: true
     - name: Storing Token ..

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
@@ -15,8 +15,8 @@
 
 - block:
     - name: Retrieve Access Token ...
-      shell: | 
-         oc whoami -t \\ 
+      shell: |
+         oc whoami -t \
          --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
       register: ocwhoami
       no_log: true
@@ -36,4 +36,3 @@
   when:
     - openshift_token is defined
     - openshift_token|trim != ''
-


### PR DESCRIPTION
### What does this PR do?
One of the OC calls within the role didn't have skip TLS option availlable, that PR is to align that call with all of the others.

### How should this be tested?
See test directory

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
