### PR TITLE
Enable the toggle "allow_simultaneous" on job templates

### DIFF
--- a/roles/ansible/tower/manage-job-templates/templates/job-template.j2
+++ b/roles/ansible/tower/manage-job-templates/templates/job-template.j2
@@ -30,6 +30,6 @@
     "survey_enabled": false,
     "become_enabled": {{ job_template.enable_privilege_escalation | default(false) }},
     "diff_mode": false,
-    "allow_simultaneous": true,
+    "allow_simultaneous": {{ job_template.allow_simultaneous | default(true) }}, 
     "webhook_service": "{{ job_template.webhook_service | default('') }}"
 }


### PR DESCRIPTION
### What does this PR do?
Allows toggling allow_simultaneous on job templates, which is currently hard coded to true. This will still default to true to not change existing inventories behavior.

### People to notify
cc: @redhat-cop/infra-ansible
