### PR TITLE
Enable tower project update from source for existing projects

### DIFF
--- a/roles/ansible/tower/manage-projects/README.md
+++ b/roles/ansible/tower/manage-projects/README.md
@@ -24,6 +24,10 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.projects.scm_credential_name|SCM credential name to use|no|null|
 |ansible_tower.projects.scm_update_on_launch|Update the project revision prior to job launch|no|false|
 |ansible_tower.projects.organization|Name of the organziation to associate this project with|yes||
+|ansible_tower.projects.scm_update_project|Update project with latest data from source control|no|false|
+|ansible_tower.projects.scm_update_wait|Wait for update to complete when updating source project|no|false|
+|ansible_tower.projects.scm_project_update_delay|Delay between retries when updating project froms source control|no|5|
+|ansible_tower.projects.scm_project_update_retries|Retries when updating project from source control|no|6|
 
 **_Note:_** Job Template configuration will **only** happen if the `ansible_tower.projects` portion of the dictionary is defined. Likewise, the installation expects this section to be "complete" if specified as it otherwise may error out.
 

--- a/roles/ansible/tower/manage-projects/README.md
+++ b/roles/ansible/tower/manage-projects/README.md
@@ -18,21 +18,23 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |:---------|:------------|:---------|:---------|
 |ansible_tower.projects.name|Name of the project|yes||
 |ansible_tower.projects.description|Description of the project|no||
+|ansible_tower.projects.organization|Name of the organziation to associate this project with|yes||
 |ansible_tower.projects.scm_type|Type of source control management to use|no|git|
 |ansible_tower.projects.scm_url|URL to the SCM source|no||
 |ansible_tower.projects.scm_branch|SCM branch to use|no|master|
 |ansible_tower.projects.scm_credential_name|SCM credential name to use|no|null|
-|ansible_tower.projects.scm_update_on_launch|Update the project revision prior to job launch|no|false|
-|ansible_tower.projects.organization|Name of the organziation to associate this project with|yes||
-|ansible_tower.projects.scm_update_project|Update project with latest data from source control|no|false|
-|ansible_tower.projects.scm_update_wait|Wait for update to complete when updating source project|no|false|
-|ansible_tower.projects.scm_project_update_delay|Delay between retries when updating project froms source control|no|5|
-|ansible_tower.projects.scm_project_update_retries|Retries when updating project from source control|no|6|
+|ansible_tower.projects.scm_update_on_launch|Update the project revision prior to job launch. Best used for "playbook" projects|no|false|
+|ansible_tower.projects.scm_project_update|Update existing project with latest data from source control.Best used for "inventory" projects|no|false|
+|ansible_tower.projects.scm_project_update_wait|Wait for update to complete when updating existing source project|no|true|
+|ansible_tower.projects.scm_project_update_delay|Delay between retries when updating existing project froms source control|no|5|
+|ansible_tower.projects.scm_project_update_retries|Retries when updating existing project from source control|no|6|
 
 **_Note:_** Job Template configuration will **only** happen if the `ansible_tower.projects` portion of the dictionary is defined. Likewise, the installation expects this section to be "complete" if specified as it otherwise may error out.
 
 
 ## Example Inventory
+
+Example project containing playbooks for job templates:
 
 ```yaml
 ---
@@ -40,14 +42,32 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 ansible_tower:
   admin_password: "admin01"
   projects:
-  - name: "Project1"
-    description: "My Project"
+  - name: "Job Template Project"
+    description: "This project will be updated by Ansible Tower each time a job template is launched using a playbook from this project. May also contain inventory, however only playbook launches will update SCM"
+    organization: "Default"
     scm_type: "git"
     scm_url: "https://github.com/redhat-cop/infra-ansible.git"
     scm_branch: "master"
     scm_credential_name: "my-credential"
     scm_update_on_launch: true
+```
+
+Example project containing inventories from source which will be create or updated from source:
+
+```yaml
+---
+
+ansible_tower:
+  admin_password: "admin01"
+  projects:
+  - name: "Inventory Only Project"
+    description: "Projects which only contain inventories can be created (or updated if existing) using this type of inventory"
     organization: "Default"
+    scm_type: "git"
+    scm_url: "https://github.com/redhat-cop/infra-ansible.git"
+    scm_branch: "master"
+    scm_credential_name: "my-credential"
+    scm_project_update: true
 ```
 
 ## Example Playbook

--- a/roles/ansible/tower/manage-projects/README.md
+++ b/roles/ansible/tower/manage-projects/README.md
@@ -27,7 +27,7 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.projects.scm_project_update|Update existing project with latest data from source control.Best used for "inventory" projects|no|false|
 |ansible_tower.projects.scm_project_update_wait|Wait for update to complete when updating existing source project|no|false|
 |ansible_tower.projects.scm_project_update_delay|Delay between retries when updating existing project froms source control|no|5|
-|ansible_tower.projects.scm_project_update_retries|Retries when updating existing project from source control|no|6|
+|ansible_tower.projects.scm_project_update_retries|Retries when updating existing project from source control|no|12|
 
 **_Note:_** Job Template configuration will **only** happen if the `ansible_tower.projects` portion of the dictionary is defined. Likewise, the installation expects this section to be "complete" if specified as it otherwise may error out.
 
@@ -47,7 +47,7 @@ ansible_tower:
     organization: "Default"
     scm_type: "git"
     scm_url: "https://github.com/redhat-cop/infra-ansible.git"
-    scm_branch: "master"
+    scm_branch: "main"
     scm_credential_name: "my-credential"
     scm_update_on_launch: true
 ```
@@ -64,8 +64,8 @@ ansible_tower:
     description: "Projects which only contain inventories can be created (or updated if existing) using this type of inventory"
     organization: "Default"
     scm_type: "git"
-    scm_url: "https://github.com/redhat-cop/infra-ansible.git"
-    scm_branch: "master"
+    scm_url: "https://github.com/project/example_repository.git"
+    scm_branch: "main"
     scm_credential_name: "my-credential"
     scm_project_update: true
 ```

--- a/roles/ansible/tower/manage-projects/README.md
+++ b/roles/ansible/tower/manage-projects/README.md
@@ -25,7 +25,7 @@ The variables used must be defined in the Ansible Inventory using the `ansible_t
 |ansible_tower.projects.scm_credential_name|SCM credential name to use|no|null|
 |ansible_tower.projects.scm_update_on_launch|Update the project revision prior to job launch. Best used for "playbook" projects|no|false|
 |ansible_tower.projects.scm_project_update|Update existing project with latest data from source control.Best used for "inventory" projects|no|false|
-|ansible_tower.projects.scm_project_update_wait|Wait for update to complete when updating existing source project|no|true|
+|ansible_tower.projects.scm_project_update_wait|Wait for update to complete when updating existing source project|no|false|
 |ansible_tower.projects.scm_project_update_delay|Delay between retries when updating existing project froms source control|no|5|
 |ansible_tower.projects.scm_project_update_retries|Retries when updating existing project from source control|no|6|
 

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -66,10 +66,6 @@
     - project_update_uri is defined
     - project.scm_project_update | default(false) is true
 
-- name:
-  debug:
-    var: project_update_response
-
 - name: "Wait for Project Update"
   uri:
     url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_response.json.url }}"
@@ -89,7 +85,7 @@
   when:
     - project_update_response.url is defined
     - project_update_response.status == 202
-    - project.scm_project_update_wait | default(true) == true
+    - project.scm_project_update_wait | default(false) == true
   failed_when: waiting_project_update.json.status == "failed"
   changed_when: waiting_project_update.json.status == "successful"
 

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get the project update url based on the project name"
   set_fact:
-    project_update_uri: "{{ item.related.update }}"
+    project_update_uri: "{{ item['related']['update'] }}"
   when:
     - item.name|trim == project.name|trim
   with_items:
@@ -62,12 +62,17 @@
     status_code: 202
   register: project_update_response
   when:
+    - project_output.status == 400
     - project_update_uri is defined
-    - project.scm_update_project | default(false) is true
+    - project.scm_project_update | default(false) is true
+
+- name:
+  debug:
+    var: project_update_response
 
 - name: "Wait for Project Update"
   uri:
-    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_response.url }}"
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_response.json.url }}"
     user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
     password: "{{ ansible_tower.admin_password }}"
     force_basic_auth: yes
@@ -79,12 +84,12 @@
     status_code: 200
   register: waiting_project_update
   until: waiting_project_update.json.status == "successful" or waiting_project_update.json.status == "failed"
-  delay: "{{ project.scm_project_update_delay | int | default(5) }}"
-  retries: "{{ project.scm_project_update_retries | int | default(6) }}"
+  delay: "{{ project.scm_project_update_delay | default(5) }}"
+  retries: "{{ project.scm_project_update_retries | default(6) }}"
   when:
     - project_update_response.url is defined
     - project_update_response.status == 202
-    - project.wait | default(false) == true
+    - project.scm_project_update_wait | default(true) == true
   failed_when: waiting_project_update.json.status == "failed"
   changed_when: waiting_project_update.json.status == "successful"
 

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -40,7 +40,7 @@
     force_basic_auth: yes
     method: POST
     body: "{{ lookup('template', 'project.j2') }}"
-    body_format: "json"
+    body_format: 'json'
     headers:
       Content-Type: "application/json"
       Accept: "application/json"

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -1,81 +1,81 @@
 ---
-- name: 'Get the project update url based on the project name'
+- name: "Get the project update url based on the project name"
   set_fact:
-    project_update_uri: '{{ item.related.update }}'
+    project_update_uri: "{{ item.related.update }}"
   when:
     - item.name|trim == project.name|trim
   with_items:
-    - '{{ existing_projects_output.rest_output }}'
+    - "{{ existing_projects_output.rest_output }}"
 
-- name: 'Get the org id based on the org name'
+- name: "Get the org id based on the org name"
   set_fact:
-    org_id: '{{ item.id }}'
+    org_id: "{{ item.id }}"
   when:
     - item.name|trim == project.organization|trim
   with_items:
-    - '{{ existing_organizations_output.rest_output }}'
+    - "{{ existing_organizations_output.rest_output }}"
 
-- name: 'Get the credential id based on the credential name'
+- name: "Get the credential id based on the credential name"
   block:
-    - name: 'Get the credential'
+    - name: "Get the credential"
       rest_get:
-        host_url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}'
-        rest_user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-        rest_password: '{{ ansible_tower.admin_password }}'
-        api_uri: '/api/v2/credentials/?name={{ project.scm_credential_name }}'
+        host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
+        rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+        rest_password: "{{ ansible_tower.admin_password }}"
+        api_uri: "/api/v2/credentials/?name={{ project.scm_credential_name }}"
       register: r_credential
-    - name: 'Set credential_id fact'
+    - name: "Set credential_id fact"
       set_fact:
-        credential_id: '{{ r_credential.rest_output[0].id | int }}'
+        credential_id: "{{ r_credential.rest_output[0].id | int }}"
       when:
         - r_credential.rest_output | length > 0
   when:
     - project.scm_credential_name is defined
 
-- name: 'Load up the project'
+- name: "Load up the project"
   uri:
-    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/projects/'
-    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-    password: '{{ ansible_tower.admin_password }}'
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/projects/"
+    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+    password: "{{ ansible_tower.admin_password }}"
     force_basic_auth: yes
     method: POST
     body: "{{ lookup('template', 'project.j2') }}"
-    body_format: 'json'
+    body_format: "json"
     headers:
-      Content-Type: 'application/json'
-      Accept: 'application/json'
-    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+      Content-Type: "application/json"
+      Accept: "application/json"
+    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 200,201,400
   register: project_output
 
-- name: 'Update existing project from source'
+- name: "Update existing project from source"
   uri:
-    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_uri }}'
-    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-    password: '{{ ansible_tower.admin_password }}'
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_uri }}"
+    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+    password: "{{ ansible_tower.admin_password }}"
     force_basic_auth: yes
     method: POST
     headers:
-      Content-Type: 'application/json'
-      Accept: 'application/json'
-    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+      Content-Type: "application/json"
+      Accept: "application/json"
+    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 202
   register: project_update_response
   when:
     - project_update_uri is defined
     - project.scm_update_project | default(false) is true
 
-- name: 'Wait for Project Update'
+- name: "Wait for Project Update"
   uri:
-    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_response.url }}'
-    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-    password: '{{ ansible_tower.admin_password }}'
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_response.url }}"
+    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+    password: "{{ ansible_tower.admin_password }}"
     force_basic_auth: yes
     method: GET
     headers:
-      Content-Type: 'application/json'
-      Accept: 'application/json'
-    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+      Content-Type: "application/json"
+      Accept: "application/json"
+    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 200
   register: waiting_project_update
   until: waiting_project_update.json.status == "successful" or waiting_project_update.json.status == "failed"
@@ -88,8 +88,8 @@
   failed_when: waiting_project_update.json.status == "failed"
   changed_when: waiting_project_update.json.status == "successful"
 
-- name: 'Clear/Update facts'
+- name: "Clear/Update facts"
   set_fact:
     credential_id: null
-    org_id: ''
+    org_id: ""
     processed_projects: "{{ processed_projects + [ { 'name': project.name } ] }}"

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -81,7 +81,7 @@
   register: waiting_project_update
   until: waiting_project_update.json.status == "successful" or waiting_project_update.json.status == "failed"
   delay: "{{ project.scm_project_update_delay | default(5) }}"
-  retries: "{{ project.scm_project_update_retries | default(6) }}"
+  retries: "{{ project.scm_project_update_retries | default(12) }}"
   when:
     - project_update_response.url is defined
     - project_update_response.status == 202

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -91,5 +91,5 @@
 - name: "Clear/Update facts"
   set_fact:
     credential_id: null
-    org_id: ""
+    org_id: ''
     processed_projects: "{{ processed_projects + [ { 'name': project.name } ] }}"

--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -1,47 +1,94 @@
 ---
-
-- name: "Get the org id based on the org name"
+- name: 'Get the project update url based on the project name'
   set_fact:
-    org_id: "{{ item.id }}"
+    project_update_uri: '{{ item.related.update }}'
   when:
-  - item.name|trim == project.organization|trim
+    - item.name|trim == project.name|trim
   with_items:
-  - "{{ existing_organizations_output.rest_output }}"
+    - '{{ existing_projects_output.rest_output }}'
 
-- name: "Get the credential id based on the credential name"
-  block:
-  - name: "Get the credential"
-    rest_get:
-      host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
-      rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-      rest_password: "{{ ansible_tower.admin_password }}"
-      api_uri: "/api/v2/credentials/?name={{ project.scm_credential_name }}"
-    register: r_credential
-  - name: "Set credential_id fact"
-    set_fact:
-      credential_id: "{{ r_credential.rest_output[0].id | int }}"
-    when:
-    - r_credential.rest_output | length > 0
+- name: 'Get the org id based on the org name'
+  set_fact:
+    org_id: '{{ item.id }}'
   when:
-  - project.scm_credential_name is defined
+    - item.name|trim == project.organization|trim
+  with_items:
+    - '{{ existing_organizations_output.rest_output }}'
 
-- name: "Load up the project"
+- name: 'Get the credential id based on the credential name'
+  block:
+    - name: 'Get the credential'
+      rest_get:
+        host_url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}'
+        rest_user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+        rest_password: '{{ ansible_tower.admin_password }}'
+        api_uri: '/api/v2/credentials/?name={{ project.scm_credential_name }}'
+      register: r_credential
+    - name: 'Set credential_id fact'
+      set_fact:
+        credential_id: '{{ r_credential.rest_output[0].id | int }}'
+      when:
+        - r_credential.rest_output | length > 0
+  when:
+    - project.scm_credential_name is defined
+
+- name: 'Load up the project'
   uri:
-    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/projects/"
-    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-    password: "{{ ansible_tower.admin_password }}"
+    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/projects/'
+    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+    password: '{{ ansible_tower.admin_password }}'
     force_basic_auth: yes
     method: POST
     body: "{{ lookup('template', 'project.j2') }}"
     body_format: 'json'
     headers:
-      Content-Type: "application/json"
-      Accept: "application/json"
-    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
+      Content-Type: 'application/json'
+      Accept: 'application/json'
+    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
     status_code: 200,201,400
   register: project_output
 
-- name: "Clear/Update facts"
+- name: 'Update existing project from source'
+  uri:
+    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_uri }}'
+    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+    password: '{{ ansible_tower.admin_password }}'
+    force_basic_auth: yes
+    method: POST
+    headers:
+      Content-Type: 'application/json'
+      Accept: 'application/json'
+    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+    status_code: 202
+  register: project_update_response
+  when:
+    - project_update_uri is defined
+    - project.scm_update_project | default(false) is true
+
+- name: 'Wait for Project Update'
+  uri:
+    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}{{ project_update_response.url }}'
+    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+    password: '{{ ansible_tower.admin_password }}'
+    force_basic_auth: yes
+    method: GET
+    headers:
+      Content-Type: 'application/json'
+      Accept: 'application/json'
+    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+    status_code: 200
+  register: waiting_project_update
+  until: waiting_project_update.json.status == "successful" or waiting_project_update.json.status == "failed"
+  delay: "{{ project.scm_project_update_delay | int | default(5) }}"
+  retries: "{{ project.scm_project_update_retries | int | default(6) }}"
+  when:
+    - project_update_response.url is defined
+    - project_update_response.status == 202
+    - project.wait | default(false) == true
+  failed_when: waiting_project_update.json.status == "failed"
+  changed_when: waiting_project_update.json.status == "successful"
+
+- name: 'Clear/Update facts'
   set_fact:
     credential_id: null
     org_id: ''


### PR DESCRIPTION
### What does this PR do?
Enables an update from scm for existing projects including an option to wait for the update job to complete.

The use case for this is when a project is "inventory only" and will not benefit from the Ansible Tower "update scm on launch" functionality which only benefits the "playbook" project when the two are disconnected.

### How should this be tested?
TBD (will keep in draft until testing is complete)

### Is there a relevant Issue open for this?
Old issue stating this is working as intended: https://github.com/ansible/awx/issues/248

### People to notify
cc: @redhat-cop/infra-ansible
