### PR TITLE
Improve performance on Tower schedule runs with bugfix for missing schedules

### DIFF
--- a/roles/ansible/tower/manage-projects/tasks/process-project.yml
+++ b/roles/ansible/tower/manage-projects/tasks/process-project.yml
@@ -64,7 +64,7 @@
   when:
     - project_output.status == 400
     - project_update_uri is defined
-    - project.scm_project_update | default(false) is true
+    - project.scm_project_update | default(false) == true
 
 - name: "Wait for Project Update"
   uri:

--- a/roles/ansible/tower/manage-schedules/tasks/main.yml
+++ b/roles/ansible/tower/manage-schedules/tasks/main.yml
@@ -3,7 +3,6 @@
     - name: "Set default values"
       set_fact:
         existing_schedules_output: []
-        processed_schedules: []
 
     # Utilize the `rest_get` library routine to ensure REST pagination is handled
     - name: "Get the existing schedules"

--- a/roles/ansible/tower/manage-schedules/tasks/process-schedule.yml
+++ b/roles/ansible/tower/manage-schedules/tasks/process-schedule.yml
@@ -1,63 +1,69 @@
 ---
-
-- name: "Get the schedule id based on the name"
-  set_fact:
-    schedule_id: "{{ item.id }}"
-  when:
-    - item.name|trim == schedule.name|trim
-  with_items:
-    - "{{ existing_schedules_output.rest_output }}"
-
-- name: "Get the Job Template ID based on the Unified Job Template name"
+- name: 'Get the Job Template ID based on the Unified Job Template name'
   block:
-    - name: "Get the unified_job_template"
+    - name: 'Get the unified_job_template'
       rest_get:
-        host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
-        rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-        rest_password: "{{ ansible_tower.admin_password }}"
-        api_uri: "/api/v2/unified_job_templates/?name={{ schedule.unified_job_template }}"
+        host_url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}'
+        rest_user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+        rest_password: '{{ ansible_tower.admin_password }}'
+        api_uri: '/api/v2/unified_job_templates/?name={{ schedule.unified_job_template }}'
       register: r_unified_job_template
-    - name: "Set unified_job_template_id fact"
+    - name: 'Set unified_job_template_id fact'
       set_fact:
-        unified_job_template_id: "{{ r_unified_job_template.rest_output[0].id | int }}"
+        unified_job_template_id: '{{ r_unified_job_template.rest_output[0].id | int }}'
       when:
         - r_unified_job_template.rest_output | length > 0
   when:
     - schedule.unified_job_template is defined
 
-- name: "Load up the schedule"
+- name: 'Load up the schedule'
   uri:
-    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/"
-    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-    password: "{{ ansible_tower.admin_password }}"
+    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/'
+    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+    password: '{{ ansible_tower.admin_password }}'
     force_basic_auth: yes
     method: POST
     body: "{{ lookup('template', 'schedule.j2') }}"
-    body_format: "json"
+    body_format: 'json'
     headers:
-      Content-Type: "application/json"
-      Accept: "application/json"
-    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
-    status_code: 201
-  when: schedule_id is not defined
+      Content-Type: 'application/json'
+      Accept: 'application/json'
+    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+    status_code: 201,400
+  register: tower_schedule_output
 
-- name: "Update existing schedule"
-  uri:
-    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/{{ schedule_id }}/"
-    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-    password: "{{ ansible_tower.admin_password }}"
-    force_basic_auth: yes
-    method: PUT
-    body: "{{ lookup('template', 'schedule.j2') }}"
-    body_format: "json"
-    headers:
-      Content-Type: "application/json"
-      Accept: "application/json"
-    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
-    status_code: 200
-  when: schedule_id is defined
+- name: 'Get the existing Schedule ID based on the Schedule name and update existing schedule'
+  block:
+    - name: 'Get the schedule_id'
+      rest_get:
+        host_url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}'
+        rest_user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+        rest_password: '{{ ansible_tower.admin_password }}'
+        api_uri: '/api/v2/schedules/?name={{ schedule.name }}'
+      register: r_schedules
+    - name: 'Set schedule_id fact'
+      set_fact:
+        schedule_id: '{{ r_schedules.rest_output[0].id }}'
+      when:
+        - r_schedules.rest_output | length > 0
+    - name: 'Update existing schedule'
+      uri:
+        url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/{{ schedule_id }}/'
+        user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
+        password: '{{ ansible_tower.admin_password }}'
+        force_basic_auth: yes
+        method: PUT
+        body: "{{ lookup('template', 'schedule.j2') }}"
+        body_format: 'json'
+        headers:
+          Content-Type: 'application/json'
+          Accept: 'application/json'
+        validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+        status_code: 200
+  when:
+    - tower_schedule_output.status == 400
 
-- name: "Clear/Update facts"
+- name: 'Clear/Update facts'
   set_fact:
     unified_job_template_id: null
-    processed_schedules: "{{ processed_schedules + [ { 'name': schedule.name } ] }}"
+    schedule_id: ''

--- a/roles/ansible/tower/manage-schedules/tasks/process-schedule.yml
+++ b/roles/ansible/tower/manage-schedules/tasks/process-schedule.yml
@@ -1,69 +1,69 @@
 ---
-- name: 'Get the Job Template ID based on the Unified Job Template name'
+- name: "Get the Job Template ID based on the Unified Job Template name"
   block:
-    - name: 'Get the unified_job_template'
+    - name: "Get the unified_job_template"
       rest_get:
-        host_url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}'
-        rest_user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-        rest_password: '{{ ansible_tower.admin_password }}'
-        api_uri: '/api/v2/unified_job_templates/?name={{ schedule.unified_job_template }}'
+        host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
+        rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+        rest_password: "{{ ansible_tower.admin_password }}"
+        api_uri: "/api/v2/unified_job_templates/?name={{ schedule.unified_job_template }}"
       register: r_unified_job_template
-    - name: 'Set unified_job_template_id fact'
+    - name: "Set unified_job_template_id fact"
       set_fact:
-        unified_job_template_id: '{{ r_unified_job_template.rest_output[0].id | int }}'
+        unified_job_template_id: "{{ r_unified_job_template.rest_output[0].id | int }}"
       when:
         - r_unified_job_template.rest_output | length > 0
   when:
     - schedule.unified_job_template is defined
 
-- name: 'Load up the schedule'
+- name: "Load up the schedule"
   uri:
-    url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/'
-    user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-    password: '{{ ansible_tower.admin_password }}'
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/"
+    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+    password: "{{ ansible_tower.admin_password }}"
     force_basic_auth: yes
     method: POST
     body: "{{ lookup('template', 'schedule.j2') }}"
-    body_format: 'json'
+    body_format: "json"
     headers:
-      Content-Type: 'application/json'
-      Accept: 'application/json'
-    validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+      Content-Type: "application/json"
+      Accept: "application/json"
+    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 201,400
   register: tower_schedule_output
 
-- name: 'Get the existing Schedule ID based on the Schedule name and update existing schedule'
+- name: "Get the existing Schedule ID based on the Schedule name and update existing schedule"
   block:
-    - name: 'Get the schedule_id'
+    - name: "Get the schedule_id"
       rest_get:
-        host_url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}'
-        rest_user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-        rest_password: '{{ ansible_tower.admin_password }}'
-        api_uri: '/api/v2/schedules/?name={{ schedule.name }}'
+        host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
+        rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+        rest_password: "{{ ansible_tower.admin_password }}"
+        api_uri: "/api/v2/schedules/?name={{ schedule.name }}"
       register: r_schedules
-    - name: 'Set schedule_id fact'
+    - name: "Set schedule_id fact"
       set_fact:
-        schedule_id: '{{ r_schedules.rest_output[0].id }}'
+        schedule_id: "{{ r_schedules.rest_output[0].id }}"
       when:
         - r_schedules.rest_output | length > 0
-    - name: 'Update existing schedule'
+    - name: "Update existing schedule"
       uri:
-        url: '{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/{{ schedule_id }}/'
-        user: '{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}'
-        password: '{{ ansible_tower.admin_password }}'
+        url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/schedules/{{ schedule_id }}/"
+        user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+        password: "{{ ansible_tower.admin_password }}"
         force_basic_auth: yes
         method: PUT
         body: "{{ lookup('template', 'schedule.j2') }}"
-        body_format: 'json'
+        body_format: "json"
         headers:
-          Content-Type: 'application/json'
-          Accept: 'application/json'
-        validate_certs: '{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}'
+          Content-Type: "application/json"
+          Accept: "application/json"
+        validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
         status_code: 200
   when:
     - tower_schedule_output.status == 400
 
-- name: 'Clear/Update facts'
+- name: "Clear/Update facts"
   set_fact:
     unified_job_template_id: null
-    schedule_id: ''
+    schedule_id: ""


### PR DESCRIPTION
### What does this PR do?
- Fix a condition in latest process-project update where `is true` fails and should be `== true`
- Use the `400` response code when creating a schedule with a `POST` to determine if it should instead be updated with a `PUT`
- Use `/api/v2/schedules/?name={{ schedule.name }}` to lookup existing schedules instead of looping through all schedules. This will enhance performance while bypassing a potential bug where not all schedules show up in the global `/api/v2/schedules` even when accounting for pagination. (The API browser is also missing some schedules from the global endpoint)

### How should this be tested?
Tested all changes against one of the failing playbooks in Tower by pointing to the incoming paulbarfuss/infra-ansible fork/branch.

For some unknown reason, when looking up all schedules in {{ ansible_tower_url }}/api/v2/schedules/ using the `rest_get` module a few are not appearing. For example:
- `{{ ansible_tower_url }}/api/v2/schedules/86` does not appear in the global schedules
- `{{ ansible_tower_url }}/api/v2/job_templates/94/schedules/` does include the schedule with `"id": 86`
- `{{ ansible_tower_url }}/api/v2/schedules/?name={{ schedule.name }}` quickly finds the correct `schedule.id` and only checks once we know from the `400` response code that the schedule does indeed already exist.

### People to notify
cc: @redhat-cop/infra-ansible
