### PR TITLE
Update playbook to add cc list

### DIFF
--- a/playbooks/notifications/email-notify-list-of-users.yml
+++ b/playbooks/notifications/email-notify-list-of-users.yml
@@ -18,5 +18,9 @@
         list_of_mail_to: "{{ list_of_mail_to | default([]) }} + [ '{{ item.email }}' ]"
       with_items:
         - "{{ list_of_users }}"
+    - set_fact:
+        list_of_mail_cc: "{{ list_of_mail_cc | default([]) }} + [ '{{ item.email }}' ]"
+      with_items:
+        - "{{ list_of_users_cc | default ([]) }}"
     - include_role:
         name: notifications/send-email


### PR DESCRIPTION
### What does this PR do?
Update the email-notify-list-of-users.yaml playbook to generate list of
cc users.

### How should this be tested?
ansible-playbook \
 -i <test_inventory> \
 infra-ansible/playbooks/notifications/email-notify-list-of-users.yml \
 -e list_of_users="<Users list>" \
 -e list_of_users_cc="<users list to be added to cc>" \
 -e title="<email title>" -e body="<email body>"

### People to notify
cc: @redhat-cop/infra-ansible
