### PR TITLE
Add roles required for user reset

### DIFF
--- a/roles/file-management/remove-files/README.md
+++ b/roles/file-management/remove-files/README.md
@@ -1,0 +1,51 @@
+Remove Files
+=========
+
+Given a directory, remove all files which content matches a given pattern.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+| Variable | Default | Description |
+| :------- | :------ | :---------- |
+| directory | None | Directory to search |
+| files | * | File pattern to restrict to |
+| match | None | The match to search the files for |
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+```yaml
+- name: Remove some files that contain foobar
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: "Remove foobar files"
+      include_role:
+        name: files/remove-files
+      vars:
+        dry_run: False
+        directory: "path/to/a/dir/with/files"
+        files: "files-with-foo.json"
+        match: "foobar"
+```
+
+License
+-------
+
+Apache License 2.0
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/file-management/remove-files/defaults/main.yml
+++ b/roles/file-management/remove-files/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for remove-files

--- a/roles/file-management/remove-files/handlers/main.yml
+++ b/roles/file-management/remove-files/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for remove-files

--- a/roles/file-management/remove-files/meta/main.yml
+++ b/roles/file-management/remove-files/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+dependencies: []

--- a/roles/file-management/remove-files/tasks/flag-file-for-removal.yml
+++ b/roles/file-management/remove-files/tasks/flag-file-for-removal.yml
@@ -1,0 +1,43 @@
+---
+
+- name: Process files
+  block:
+
+    - name: Processing message
+      debug:
+        msg:
+          - "Searching for {{ item.1 }} in {{ item.0 }}"
+
+    # This task will report success if the regexp was found.
+    - name: Search for content in file
+      lineinfile:
+        path: "{{ item.0 }}"
+        regexp: "{{ item.1 }}"
+        state: absent
+      check_mode: True
+      ignore_errors: True
+      register: file_match
+      failed_when: not file_match.changed
+
+    - name: No Match
+      debug:
+        msg:
+          - "No match found for {{ item.1 }} in {{ item.0 }}"
+      when:
+        - not file_match is successful
+
+    - name: Match found
+      debug:
+        msg:
+          - "Match found for {{ item.1 }} in {{ item.0 }}"
+      when:
+        - file_match is successful
+
+    - name: Mark file for removal
+      set_fact:
+        files_to_remove: "{{ (files_to_remove | default([])) + [ item.0 ] }}"
+      when:
+        - file_match is successful
+
+  when:
+    - match is iterable

--- a/roles/file-management/remove-files/tasks/main.yml
+++ b/roles/file-management/remove-files/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+
+- name: Pre-flight checks
+  assert:
+    that: "{{ assertion.that }}"
+    fail_msg: "{{ assertion.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: assertion
+  loop:
+    - msg: A directory path must be provided to search
+      that:
+        - directory is defined
+    - msg: A match for file content must be provided
+      that:
+        - match is defined
+
+- name: "Check the directory actually exists"
+  ansible.builtin.stat:
+    path: "{{ directory }}"
+  register: result_directory
+  ignore_errors: True
+
+- name: Determine the list of files to be searched
+  block:
+
+    - name: Processing directory
+      debug:
+        msg:
+          - "Looking for {{ files }} within {{ directory }}"
+
+    - name: Collect list of files
+      find:
+        paths: "{{ directory }}"
+        patterns: "{{ files | default('*') }}"
+      register: files_to_process
+
+  when:
+    - result_directory.stat.isdir is defined
+
+- name: Remove matching files
+  block:
+
+    - name: Setup counter for files to remove
+      set_fact:
+        files_to_remove: []
+
+    - name: Set the list of files to check
+      set_fact:
+        files_to_check: "{{ files_to_process.files | map(attribute='path') | list | unique }}"
+
+    - name: Process each file and flag for removal
+      include_tasks: flag-file-for-removal.yml
+      loop: "{{ files_to_check | product(match) | list }}"
+
+    - name: Notify files marked for removal
+      debug:
+        msg:
+          - "The following files have been marked for removal"
+          - "{{ files_to_remove | list }}"
+
+    - name: Remove files marked for removal
+      file:
+        path: "{{ file }}"
+        state: absent
+      with_items:
+        - "{{ files_to_remove }}"
+      loop_control:
+        loop_var: file
+      when:
+        - not dry_run | bool
+
+  when:
+    - result_directory.stat.isdir is defined
+    - files_to_process is defined

--- a/roles/file-management/remove-files/tests/inventory
+++ b/roles/file-management/remove-files/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/file-management/remove-files/tests/test.yml
+++ b/roles/file-management/remove-files/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - remove-files

--- a/roles/file-management/remove-files/vars/main.yml
+++ b/roles/file-management/remove-files/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for remove-files

--- a/roles/identity-management/manage-idm-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-idm-identities/tasks/create_users.yml
@@ -3,7 +3,7 @@
 - name: "Process users for IPA/IdM"
   block:
 
-    - name: Create IPA/IdM user
+    - name: Manage IPA/IdM user
       ipa_user:
         ipa_host: "{{ ipa_host | default(ansible_host)}}"
         ipa_user: "{{ ipa_admin_user }}"

--- a/roles/scm/git/README.md
+++ b/roles/scm/git/README.md
@@ -1,0 +1,66 @@
+Role Name
+=========
+
+A role to pull and push git repositories.
+
+Requirements
+------------
+
+Pulling git repositories uses the Ansible module.
+
+Pushing git repositories requires the git cli.
+
+Role Variables
+--------------
+
+Role variables are defined in `defaults/main.yml`.
+
+Dependencies
+------------
+
+No dependencies.
+
+Example Playbook
+----------------
+
+```yaml
+- name: Pull and push a git repo
+  hosts: localhost
+  gather_facts: no
+  tasks:
+
+    - name: "Clone git repository"
+      include_role:
+        name: scm/git
+      vars:
+        action: pull
+      when:
+        - repository is defined
+      tags:
+        - always
+
+    - name: "Touch a file inside the repo"
+      file:
+        path: "{{ scm_dir }}/hello_worls.txt"
+        state: touch
+
+    - name: "Commit changes and push git repository"
+      include_role:
+        name: scm/git
+      vars:
+        action: push
+      when:
+        - repository is defined
+      tags:
+        - always
+```
+
+License
+-------
+
+Apache License 2.0
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/scm/git/defaults/main.yml
+++ b/roles/scm/git/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+
+#########################
+# Defaults
+#########################
+
+git:
+  name: Git Bot
+  username: git-bot
+  email: git-bot@no-reply
+  message: "Auto-update files"
+  remove_local: false
+
+# Example using HTTP
+#repository:
+#  name: example
+#  url: https://github.com/org/repo.git
+#  branch: main
+#  username: hello
+#  password: password
+
+# Example using SSH
+#repository:
+#  name: example
+#  url: ssh://git@github.com/org/repo.git
+#  branch: main
+#  ssh_key: "{{ lookup('file', '/var/home/mahdtech/.ssh/id_ed25519') }}"

--- a/roles/scm/git/handlers/main.yml
+++ b/roles/scm/git/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Clean-up temporary SSH directory
+  file:
+    path: "{{ ssh_dir }}"
+    state: absent
+  changed_when: false
+  listen:
+    - Remove SSH keys
+
+- name: Remove git credentials
+  include_tasks:
+    file: remove_git_creds.yml
+  listen: Remove git credentials

--- a/roles/scm/git/handlers/remove_git_creds.yml
+++ b/roles/scm/git/handlers/remove_git_creds.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Remove local git credentials
+  block:
+
+    - name: Set the git username
+      shell: git config --local user.name ""
+      args:
+        chdir: "{{ scm_dir.path }}"
+
+    - name: Set the git password
+      shell: git config --local user.password ""
+      args:
+        chdir: "{{ scm_dir.path }}"
+
+  when:
+    - repository.username is defined
+    - repository.password is defined
+    - scm_dir.path is defined

--- a/roles/scm/git/meta/main.yml
+++ b/roles/scm/git/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+dependencies: []

--- a/roles/scm/git/tasks/commit.yml
+++ b/roles/scm/git/tasks/commit.yml
@@ -1,0 +1,62 @@
+---
+
+- name: Pre-flight checks
+  assert:
+    that: "{{ assertion.that }}"
+    fail_msg: "{{ assertion.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: assertion
+  loop:
+    - msg: Repository Path variable must be set in 'scm_dir'
+      that:
+        - scm_dir is defined
+
+- name: Add all new files to repository
+  shell: git add --all
+  args:
+    chdir: "{{ scm_dir }}"
+  changed_when: false
+
+- name: Show staged files
+  shell: git diff --cached --name-only
+  args:
+    chdir: "{{ scm_dir }}"
+  register: scm_files_staged
+  changed_when: false
+
+- name: Configure git username
+  shell: git config --local user.name "{{ git.username }}"
+  args:
+    chdir: "{{ scm_dir }}"
+  changed_when: false
+
+- name: Configure git email
+  shell: git config --local user.email "{{ git.email }}"
+  args:
+    chdir: "{{ scm_dir }}"
+  changed_when: false
+
+- name: Commit changes
+  shell: git commit --all --message "{{ git.message }}"
+  args:
+    chdir: "{{ scm_dir }}"
+  register: scm_commit
+  failed_when:
+    - scm_commit.rc != 0
+    - '"nothing to commit, working directory clean" not in scm_commit.stdout'
+
+- name: Files were committed
+  debug:
+    msg:
+      - "There are changes that were committed"
+  when:
+    - scm_commit is succeeded
+
+- name: No files were committed
+  debug:
+    msg:
+      - "There are no changes that were committed"
+  when: >
+    scm_commit.rc != 0 or
+    "nothing to commit" in scm_commit.stdout

--- a/roles/scm/git/tasks/main.yml
+++ b/roles/scm/git/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+
+- name: Pre-flight checks
+  assert:
+    that: "{{ assertion.that }}"
+    fail_msg: "{{ assertion.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: assertion
+  loop:
+    - msg: Repository URL variable must be set
+      that:
+        - repository.url is defined
+
+- name: Pre-flight checks (SSH Repo)
+  fail:
+    msg:
+      - "SSH Private key is expected when the URL is of type SSH"
+  when:
+    - repository.url is match ("ssh://")
+    - not repository.ssh_key is defined
+
+- name: Pre-flight checks (HTTP Repo)
+  fail:
+    msg:
+      - "Personal Access Token is expected when the URL is of type HTTP"
+  when:
+    - repository.url is regex ("^http[s]?://")
+    - ( not repository.username is defined or not repository.password is defined )
+
+- name: Pre-flight checks (Confused Repo)
+  fail:
+    msg:
+      - "Please provide either;"
+      - "   an SSH key with a url starting with ssh://"
+      - "   or a PAT with a user starting with http://"
+      - "but not both..."
+  when:
+    - repository.ssh_key is defined
+    - repository.password is defined
+
+- name: "Pull from git repository"
+  include_tasks:
+    file: pull.yml
+    apply:
+      tags:
+        - pull
+  when:
+    - action == "pull"
+
+- name: "Push to git repository"
+  include_tasks:
+    file: push.yml
+    apply:
+      tags:
+        - push
+  when:
+    - action == "push"
+
+- name: "Remove git repository"
+  include_tasks:
+    file: remove.yml
+  when:
+    - remove_local | default(false) | bool

--- a/roles/scm/git/tasks/prep.yml
+++ b/roles/scm/git/tasks/prep.yml
@@ -1,0 +1,95 @@
+---
+- name: Prepare git credentials (SSH)
+  block:
+
+    - name: Create temporary directory for SSH config
+      tempfile:
+        state: directory
+        prefix: ssh-
+      register: result_ssh_dir
+      changed_when: false
+      notify: Remove SSH keys
+
+    - name: Create temporary file for the SSH private key
+      tempfile:
+        path: "{{ result_ssh_dir.path }}"
+        prefix: "key-"
+      register: result_ssh_key
+      changed_when: false
+
+    - name: Set SSH facts
+      set_fact:
+        ssh_dir: "{{ result_ssh_dir.path }}"
+        ssh_key: "{{ result_ssh_key.path }}"
+
+    - name: Copy SSH private key to temporary file
+      copy:
+        content: "{{ repository.ssh_key | from_yaml }}"
+        dest: "{{ ssh_key }}"
+        mode: 0600
+      no_log: true
+      changed_when: false
+
+    - name: Template SSH config
+      template:
+        src: ssh_config.j2
+        dest: "{{ ssh_dir }}/config"
+        force: true
+        backup: true
+        trim_blocks: false
+        mode: 0600
+      changed_when: false
+
+    - name: Template git wrapper
+      template:
+        src: git_wrapper.j2
+        dest: "{{ ssh_dir }}/wrapper"
+        force: true
+        trim_blocks: false
+        mode: 0700
+      changed_when: false
+
+    - name: Set the SCM repository (SSH)
+      set_fact:
+        scm_repository: "{{ repository.url }}"
+
+  when:
+    - repository.ssh_key is defined
+
+- name: Prepare git URL (HTTP)
+  block:
+    - name: Split the SCM repository URL (HTTP)
+      set_fact:
+        scm_repo_scheme: "{{ repository.url | urlsplit('scheme') }}"
+        scm_repo_hostname: "{{ repository.url | urlsplit('hostname') }}"
+        scm_repo_path: "{{ repository.url | urlsplit('path') }}"
+        scm_username: "{{ repository.username | urlencode() | regex_replace('/','%2F') }}"
+        scm_password: "{{ repository.password | urlencode() | regex_replace('/','%2F') }}"
+      no_log: true
+
+    - name: Set the SCM repository (HTTP)
+      set_fact:
+        scm_repository: "{{ scm_repo_scheme }}://{{ scm_username }}:{{ scm_password }}@{{ scm_repo_hostname }}{{ scm_repo_path }}"
+
+  when:
+    - repository.url is regex ("^http[s]?://")
+
+- name: Prepare local git credentials (HTTP)
+  block:
+
+    - name: Set the git username
+      shell: git config --local user.name "{{ repository.username }}"
+      args:
+        chdir: "{{ scm_dir }}"
+      notify: Remove git credentials
+
+    - name: Set the git password
+      shell: git config --local user.password "{{ repository.password }}"
+      args:
+        chdir: "{{ scm_dir }}"
+      notify: Remove git credentials
+
+  when:
+    - repository.username is defined
+    - repository.password is defined
+    - scm_dir is defined

--- a/roles/scm/git/tasks/pull.yml
+++ b/roles/scm/git/tasks/pull.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Prepare SCM credentials
+  include_tasks: prep.yml
+
+- name: Create temporary directory for the repository
+  tempfile:
+    state: directory
+    prefix: "repo-"
+  register: result_scm_dir
+  changed_when: false
+  when:
+    - not repository.path is defined
+
+- name: Set directory for the repository
+  set_fact:
+    scm_dir: "{{ repository.path if repository.path is defined else result_scm_dir.path }}"
+
+- name: "Clone repository to temporary location"
+  git:
+    clone: true
+    repo: "{{ scm_repository }}"
+    dest: "{{ scm_dir }}"
+    force: "{{ repository.force | default(omit) }}"
+    key_file: "{{ ssh_key | default(omit) }}"
+    remote: "{{ repository.remote | default('origin') }}"
+    # Bracket notation used to avoid public method clash
+    update: "{{ repository['update'] | default(omit) }}"
+    version: "{{ repository.version | default('HEAD') }}"
+    accept_hostkey: "{{ repository.accept_hostkey | default(omit) }}"
+  when:
+    - scm_dir is defined

--- a/roles/scm/git/tasks/push.yml
+++ b/roles/scm/git/tasks/push.yml
@@ -1,0 +1,56 @@
+---
+
+- name: Prepare SCM credentials
+  include_tasks: prep.yml
+
+- name: Commit changes
+  include_tasks: commit.yml
+
+- name: Changes to be pushed
+  debug:
+    msg:
+      - "There are changes that need to be pushed"
+  register: scm_commit_changes
+  when: >
+    scm_commit is succeeded or
+    "Your branch is ahead" in scm_commit.stdout
+
+- name: Push changes (SSH)
+  block:
+
+    - name: Debug git config
+      shell: |
+        cat "{{ ssh_dir }}/wrapper"
+        cat "{{ ssh_dir }}/config"
+        git remote -v
+      args:
+        chdir: "{{ scm_dir }}"
+
+    - name: Push to remote repository (SSH)
+      shell: git push {{ repository.remote | default('origin') }}
+      args:
+        chdir: "{{ scm_dir }}"
+
+  environment:
+    GIT_SSH: "{{ ssh_dir }}/wrapper"
+  when:
+    - repository.ssh_key is defined
+    - scm_commit_changes is defined
+
+- name: Push changes (HTTP)
+  block:
+
+    - name: Push to remote repository (HTTP)
+      shell: git push
+      args:
+        chdir: "{{ scm_dir }}"
+
+  when:
+    - repository.url is regex ("^http[s]?://")
+    - scm_commit_changes is defined
+
+- name: Show git status
+  shell: git status
+  args:
+    chdir: "{{ scm_dir }}"
+  register: scm_files_status

--- a/roles/scm/git/tasks/remove.yml
+++ b/roles/scm/git/tasks/remove.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Remove git directory
+  file:
+    path: "{{ scm_dir }}"
+    state: absent

--- a/roles/scm/git/templates/git_wrapper.j2
+++ b/roles/scm/git/templates/git_wrapper.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ssh -F {{ ssh_dir }}/config $*

--- a/roles/scm/git/templates/ssh_config.j2
+++ b/roles/scm/git/templates/ssh_config.j2
@@ -1,0 +1,13 @@
+Host *
+
+  LogLevel DEBUG
+
+  IdentityFile {{ ssh_key }}
+
+  BatchMode yes
+
+  VisualHostKey yes
+
+  StrictHostKeyChecking no
+
+  UserKnownHostsFile /dev/null

--- a/roles/scm/git/tests/inventory
+++ b/roles/scm/git/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scm/git/tests/test.yml
+++ b/roles/scm/git/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - git

--- a/roles/scm/git/vars/main.yml
+++ b/roles/scm/git/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for git


### PR DESCRIPTION
### What does this PR do?

This PR adds the following;

- [x] Role for basic git management (pull/push)
- [x] Role for removing files based on a regex content search
- [x] ~~Role for identity removal with success/fail/skip counters~~
- [x] ~~Playbook that makes use of those roles for use in LodeStar~~
- [x] Check for leftover TODO items
- [x] Incorporate feedback
- [x] Fix regression with Ansible inventories added in #636 (first run vs updates)
- [x] Resolve comments

### How should this be tested?

Roles can be tested individually, or demonstrated in conjunction with other changes in linked PR below.

### Is there a relevant Issue open for this?

None

### Other Relevant info, PRs, etc.

This is the first part of a 2-part PR, with the additional information available in [lodestar-automation #66](https://github.com/rht-labs/lodestar-automation/pull/66)

- Issue [#796](https://gitlab.consulting.redhat.com/rht-labs/labs-sre/documentation/-/issues/796) (Internal)
- Inventory [sample](https://gitlab.consulting.redhat.com/rht-labs/scratch/lodestar-sandbox/maduncan/engagements/saltlabs/user-reset/iac/-/blob/master/iac/inventories/identity-management/inventory/group_vars/all.yml#L49) (Internal)

Other related PR's include

- [Babylon Anarchy Governor #32](https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor/pull/32)
- [AgnosticV Operator #74](https://github.com/redhat-gpte-devopsautomation/agnosticv-operator/pull/74)

### People to notify

cc: @redhat-cop/infra-ansible
