### PR TITLE
Ansible Tower: Update manage-inventories

### DIFF
--- a/roles/ansible/tower/manage-inventories/tasks/main.yml
+++ b/roles/ansible/tower/manage-inventories/tasks/main.yml
@@ -8,6 +8,7 @@
       existing_organizations_output: []
       existing_projects_output: []
       existing_credentials_output: []
+      existing_inventories_output: []
 
   # Utilize the `rest_get` library routine to ensure REST pagination is handled
   - name: "Get the existing organizations"
@@ -34,12 +35,28 @@
       api_uri: "/api/v2/credentials/"
     register: existing_credentials_output
 
+  - name: "Get existing inventories"
+    rest_get:
+      host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
+      rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+      rest_password: "{{ ansible_tower.admin_password }}"
+      api_uri: "/api/v2/inventories/"
+    register: existing_inventories_output
+
   - name: "Process the inventory entries"
     include_tasks: process-inventory.yml
     with_items:
     - "{{ ansible_tower.inventories }}"
     loop_control:
       loop_var: inventory
+
+  - name: "Get updated inventories"
+    rest_get:
+      host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
+      rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+      rest_password: "{{ ansible_tower.admin_password }}"
+      api_uri: "/api/v2/inventories/"
+    register: existing_inventories_output
 
   - name: "Eliminate the inventories that should not be present"
     uri:

--- a/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
+++ b/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
@@ -29,10 +29,29 @@
       Content-Type: "application/json"
       Accept: "application/json"
     validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
-    status_code: 200,201,400
+    status_code: 200,201
   register: inventory_output
   when:
     - (inv_id is not defined) or (inv_id | length == 0)
+
+- name: "Update existing inventory"
+  uri:
+    url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/inventories/{{ inv_id }}/"
+    user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
+    password: "{{ ansible_tower.admin_password }}"
+    force_basic_auth: yes
+    method: PUT
+    body: "{{ lookup('template', 'inventory.j2') }}"
+    body_format: 'json'
+    headers:
+      Content-Type: "application/json"
+      Accept: "application/json"
+    validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
+    status_code: 200,201
+  register: inventory_output
+  when:
+    - inv_id is defined
+    - inv_id | length > 0
 
 - name: 'Get inventory id from the loaded inventory'
   set_fact:

--- a/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
+++ b/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
@@ -66,7 +66,7 @@
     - "{{ inventory.hosts }}"
   loop_control:
     loop_var: host
-  when: 
+  when:
     - inventory.hosts is defined
 
 - name: "Process the inventory group entries"
@@ -75,7 +75,7 @@
     - "{{ inventory.groups }}"
   loop_control:
     loop_var: group
-  when: 
+  when:
     - inventory.groups is defined
 
 - name: "Process the inventory sources"

--- a/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
+++ b/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
@@ -4,17 +4,17 @@
   set_fact:
     org_id: "{{ item.id }}"
   when:
-  - item.name|trim == inventory.organization|trim
+    - item.name|trim == inventory.organization|trim
   with_items:
-  - "{{ existing_organizations_output.rest_output }}"
+    - "{{ existing_organizations_output.rest_output }}"
 
 - name: "Get the inventory id based on the inventory name"
   set_fact:
     inv_id: "{{ item.id }}"
   when:
-  - item.name|trim == inventory.name|trim
+    - item.name|trim == inventory.name|trim
   with_items:
-  - "{{ existing_inventories_output.rest_output }}"
+    - "{{ existing_inventories_output.rest_output }}"
 
 - name: "Load up the inventory"
   uri:
@@ -63,23 +63,25 @@
 - name: "Process the inventory host entries"
   include_tasks: process-host.yml
   with_items:
-  - "{{ inventory.hosts }}"
+    - "{{ inventory.hosts }}"
   loop_control:
     loop_var: host
-  when: inventory.hosts is defined
+  when: 
+    - inventory.hosts is defined
 
 - name: "Process the inventory group entries"
   include_tasks: process-group.yml
   with_items:
-  - "{{ inventory.groups }}"
+    - "{{ inventory.groups }}"
   loop_control:
     loop_var: group
-  when: inventory.groups is defined
+  when: 
+    - inventory.groups is defined
 
 - name: "Process the inventory sources"
   include_tasks: process-source.yml
   with_items:
-  - "{{ inventory.sources | default([])}}"
+    - "{{ inventory.sources | default([])}}"
   loop_control:
     loop_var: source
   when: inventory.sources is defined

--- a/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
+++ b/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
@@ -8,6 +8,14 @@
   with_items:
   - "{{ existing_organizations_output.rest_output }}"
 
+- name: "Get the inventory id based on the inventory name"
+  set_fact:
+    inv_id: "{{ item.id }}"
+  when:
+  - item.name|trim == inventory.name|trim
+  with_items:
+  - "{{ existing_inventories_output.rest_output }}"
+
 - name: "Load up the inventory"
   uri:
     url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}/api/v2/inventories/"
@@ -23,23 +31,15 @@
     validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 200,201,400
   register: inventory_output
-
-# Utilize the `rest_get` library routine to ensure REST pagination is handled
-- name: "Get the updated list of existing inventories"
-  rest_get:
-    host_url: "{{ ansible_tower.url | default(default_ansible_tower_url) }}"
-    rest_user: "{{ ansible_tower.admin_username | default(default_ansible_tower_admin_username) }}"
-    rest_password: "{{ ansible_tower.admin_password }}"
-    api_uri: "/api/v2/inventories/"
-  register: existing_inventories_output
-
-- name: "Get the inventory id based on the inventory name"
-  set_fact:
-    inv_id: "{{ item.id }}"
   when:
-  - item.name|trim == inventory.name|trim
-  with_items:
-  - "{{ existing_inventories_output.rest_output }}"
+    - (inv_id is not defined) or (inv_id | length == 0)
+
+- name: 'Get inventory id from the loaded inventory'
+  set_fact:
+    inv_id: "{{ inventory_output.json.id }}"
+  when:
+    - (inv_id is not defined) or (inv_id | length == 0)
+    - inventory_output is succeeded
 
 - name: "Process the inventory host entries"
   include_tasks: process-host.yml
@@ -70,4 +70,3 @@
     org_id: ''
     inv_id: ''
     processed_inventories: "{{ processed_inventories + [ { 'name': inventory.name } ] }}"
-


### PR DESCRIPTION
### What does this PR do?

Role: ansible-tower/manage-inventories

- Move the get inventories call to outside the loop
- Use return value to capture any new inventory id
- Allow updating existing inventory with changes

### How should this be tested?

Execute role against Ansible Tower instance with and without inventories.

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc.

- #632

### People to notify

cc: @redhat-cop/infra-ansible
