### PR TITLE
Making 'aws_profile' optional to make password assingment work without

### DIFF
--- a/roles/identity-management/manage-aws-user-password/README.md
+++ b/roles/identity-management/manage-aws-user-password/README.md
@@ -1,0 +1,51 @@
+Manage AWS User password
+====================================
+
+An Ansible role that manages AWS user's password
+
+Role Variables
+--------------
+
+The following would represent a single account as an Ansible host (e.g., `host_vars/aws-profile-na-1.yml`)
+
+```yaml
+---
+
+ansible_connection: local
+
+identities:
+  targets:
+    - aws
+
+  users:
+    - user_name: admin-user
+      first_name: First
+      last_name: Last
+      email: "admin@example.com"
+
+  groups:
+    - group_name: "admin-group"
+      managed_policy_arn:
+        - "arn:aws:iam::aws:policy/AdministratorAccess"
+      members:
+        - admin-user
+```
+
+Variable Descriptions
+---------------------
+
+| Variable | Description | Required | Defaults |
+|:--------:|:-----------:|:--------:|:--------:|
+|targets|Target environment, (e.g., AWS IAM, IdM, etc)|yes|N/A|
+|users|Each user must exist in a profiles.groups.members to be created in an account|yes|N/A|
+
+License
+-------
+
+Apache License 2.0
+
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/identity-management/manage-aws-user-password/README.md
+++ b/roles/identity-management/manage-aws-user-password/README.md
@@ -1,5 +1,5 @@
 Manage AWS User password
-====================================
+========================
 
 An Ansible role that manages AWS user's password
 

--- a/roles/identity-management/manage-aws-user-password/tasks/main.yml
+++ b/roles/identity-management/manage-aws-user-password/tasks/main.yml
@@ -2,8 +2,15 @@
 
 - name: "Process password for AWS user(s)"
   block:
+    - name: Set fact for aws_profile - if requested
+      set_fact:
+        aws_profile_arg: "--profile {{ user_data.aws_profile }}"
+      when:
+        - user_data.aws_profile is defined
+        - user_data.aws_profile|length > 0
+
     - name: Set initial password for AWS user
-      command: "aws iam create-login-profile --profile {{ user_data.aws_profile }} --user-name {{ user_data.user_name }} --password {{ user_data.password }} --password-reset-required"
+      command: "aws iam create-login-profile {{ aws_profile_arg | default ('') }} --user-name {{ user_data.user_name }} --password {{ user_data.password }} --password-reset-required"
       with_items:
         - "{{ identities.users }}"
       loop_control:
@@ -14,8 +21,6 @@
         - user_data.user_name is defined
         - user_data.password is defined
         - user_data.password|length > 0
-        - user_data.aws_profile is defined
-        - user_data.aws_profile|length > 0
   when:
     - identities.users is defined
     - identities.targets is undefined or 'aws' in identities.targets


### PR DESCRIPTION
### What does this PR do?
This change makes the `aws_profile` optional so it's possible to set a password, and hence console access, without the aws_profile assigned. 

### How should this be tested?
Run a user management without an aws_profile name == success
Run a user management with an aws_profile name == success 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
