### PR TITLE
Generate password parameters for customizing strength of password 

### DIFF
--- a/roles/identity-management/manage-user-password/defaults/main.yml
+++ b/roles/identity-management/manage-user-password/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+
+generate_password_length: 16
+
+# The char set can be one of the following:
+# - ascii_lowercase
+# - ascii_uppercase
+# - digits
+# - hexdigits
+# - octdigits
+# - printable
+# - punctuation
+# - whitespace
+generate_password_char_sets: 'ascii_letters,digits,punctuation'

--- a/roles/identity-management/manage-user-password/defaults/main.yml
+++ b/roles/identity-management/manage-user-password/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-generate_password_length: 16
+generate_password_length: '16'
 
 # The char set can be one of the following:
 # - ascii_lowercase

--- a/roles/identity-management/manage-user-password/tasks/generate-password.yml
+++ b/roles/identity-management/manage-user-password/tasks/generate-password.yml
@@ -6,7 +6,7 @@
 
 - name: "Create random password"
   set_fact:
-    password: "{{ lookup('password','/dev/null length=16') }}"
+    password: "{{ lookup('password','/dev/null length=' + generate_password_length + ' chars=' + generate_password_char_sets) }}"
   when:
   - password|trim == ''
 


### PR DESCRIPTION
### What does this PR do?
Allow for passing parameters to the generate-password role to set things like length and character set to use

### How should this be tested?

Run one of the identity playbooks that use this role to generate a new password

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
