### PR TITLE
Eliminating some of the no_log flags

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/openshift_authenticate.yml
@@ -14,25 +14,21 @@
     - openshift_password|trim != ''
 
 - block:
-    - name: Retrieve Access Token ...
+    - name: Retrieve and store OpenShift Access Token
       shell: |
          oc whoami -t \
          --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
       register: ocwhoami
-      no_log: true
-    - name: Storing Token ..
-      set_fact:
+    - set_fact:
         openshift_token: "{{ ocwhoami.stdout }}"
-      no_log: true
   when:
     - openshift_token is not defined or openshift_token|trim == ''
 
-- name: Authenticate with Openshift via token
+- name: Authenticate with OpenShift via token
   shell: |
     oc login {{ openshift_host }} \
       --token '{{ openshift_token }}' \
       --insecure-skip-tls-verify="{{ openshift_skip_tls_verify | default(false) | bool }}"
-  no_log: true
   when:
     - openshift_token is defined
     - openshift_token|trim != ''


### PR DESCRIPTION
### What does this PR do?

OpenShift tokens aren't necessarily as "secret" as passwords are, and hence removing some `no_log` options for these tasks should be considered "safe". 

### How should this be tested?
Run the ansible tower deployment on OCP

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
