### PR TITLE
Fix python interpreter variable

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/templates/inventory.j2
+++ b/roles/ansible/tower/config-ansible-tower-ocp/templates/inventory.j2
@@ -1,4 +1,4 @@
-localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
+localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python3"
 
 [all:vars]
 


### PR DESCRIPTION
### What does this PR do?
Change ansible_python_interpreter environment variable to use python3 instead of python

### How should this be tested?
Run configure-ansible-tower.yml playbook in the environment where /usr/bin/python alias not set.

### People to notify
cc: @redhat-cop/infra-ansible
