### PR TITLE
Manage-workflow-templates and manage-schedules compability improvement

### DIFF
--- a/roles/ansible/tower/manage-schedules/templates/schedule.j2
+++ b/roles/ansible/tower/manage-schedules/templates/schedule.j2
@@ -1,16 +1,28 @@
 {
     "rrule": "{{ schedule.rrule }}",
     "name": "{{ schedule.name }}",
-    "description": "{{ schedule.description | default('') }}",
+{% if schedule.description is defined %}
+    "description": "{{ schedule.description }}",
+{% endif %}
+{% if schedule.extra_data is defined %}
     "extra_data": {{ schedule.extra_data | default("{}") | to_json }},
+{% endif %}
+{% if schedule.inventory is defined %}
     "inventory": "{{ schedule.inventory | default() }}",
+{% endif %}
+{% if schedule.scm_branch is defined %}
     "scm_branch": "{{ schedule.scm_branch | default('') }}",
+{% endif %}
     "job_type": null,
     "job_tags": "",
     "skip_tags": "",
+{% if schedule.limit is defined %}
     "limit": "{{ schedule.limit | default('') }}",
+{% endif %}
     "diff_mode": null,
     "verbosity": null,
     "unified_job_template": "{{ unified_job_template_id | default('') }}",
+{% if schedule.enabled is defined %}
     "enabled": {{ schedule.enabled | default(true)| bool | lower }}
+{% endif %}
 }

--- a/roles/ansible/tower/manage-schedules/templates/schedule.j2
+++ b/roles/ansible/tower/manage-schedules/templates/schedule.j2
@@ -5,24 +5,24 @@
     "description": "{{ schedule.description }}",
 {% endif %}
 {% if schedule.extra_data is defined %}
-    "extra_data": {{ schedule.extra_data | default("{}") | to_json }},
+    "extra_data": {{ schedule.extra_data | to_json }},
 {% endif %}
 {% if schedule.inventory is defined %}
-    "inventory": "{{ schedule.inventory | default() }}",
+    "inventory": "{{ schedule.inventory }}",
 {% endif %}
 {% if schedule.scm_branch is defined %}
-    "scm_branch": "{{ schedule.scm_branch | default('') }}",
+    "scm_branch": "{{ schedule.scm_branch }}",
 {% endif %}
     "job_type": null,
     "job_tags": "",
     "skip_tags": "",
 {% if schedule.limit is defined %}
-    "limit": "{{ schedule.limit | default('') }}",
+    "limit": "{{ schedule.limit }}",
 {% endif %}
     "diff_mode": null,
     "verbosity": null,
-    "unified_job_template": "{{ unified_job_template_id | default('') }}",
+    "unified_job_template": "{{ unified_job_template_id }}",
 {% if schedule.enabled is defined %}
-    "enabled": {{ schedule.enabled | default(true)| bool | lower }}
+    "enabled": {{ schedule.enabled | bool | lower }}
 {% endif %}
 }

--- a/roles/ansible/tower/manage-workflow-templates/templates/workflow-node-template.j2
+++ b/roles/ansible/tower/manage-workflow-templates/templates/workflow-node-template.j2
@@ -1,12 +1,3 @@
 {
-    "extra_data": {},
-    "inventory": null,
-    "job_type": null,
-    "job_tags": "",
-    "skip_tags": "",
-    "limit": "",
-    "diff_mode": null,
-    "verbosity": null,
-    "credential": null,
     "unified_job_template": {{ job_template_id }}
 }

--- a/roles/ansible/tower/manage-workflow-templates/templates/workflow-template.j2
+++ b/roles/ansible/tower/manage-workflow-templates/templates/workflow-template.j2
@@ -1,19 +1,19 @@
 {
     "name": "{{ workflow_template.name }}",
 {% if workflow_template.description is defined %}
-    "description": "{{ workflow_template.description | default('') }}",
+    "description": "{{ workflow_template.description }}",
 {% endif %}
 {% if workflow_template.extra_vars is defined %}
-    "extra_vars": "{{ workflow_template.extra_vars | default('') }}",
+    "extra_vars": "{{ workflow_template.extra_vars }}",
 {% endif %}
     "organization": null,
 {% if workflow_template.allow_simultaneous is defined %}
-    "allow_simultaneous": "{{ workflow_template.allow_simultaneous | default(true) }}",
+    "allow_simultaneous": "{{ workflow_template.allow_simultaneous }}",
 {% endif %}
 {% if workflow_template.ask_variables_on_launch is defined %}
-    "ask_variables_on_launch": {{workflow_template.ask_variables_on_launch | default(false) }},
+    "ask_variables_on_launch": {{workflow_template.ask_variables_on_launch }},
 {% endif %}
 {% if workflow_template.webhook_service is defined %}
-    "webhook_service": "{{ workflow_template.webhook_service | default('') }}"
+    "webhook_service": "{{ workflow_template.webhook_service }}"
 {% endif %}
 }

--- a/roles/ansible/tower/manage-workflow-templates/templates/workflow-template.j2
+++ b/roles/ansible/tower/manage-workflow-templates/templates/workflow-template.j2
@@ -1,9 +1,19 @@
 {
     "name": "{{ workflow_template.name }}",
+{% if workflow_template.description is defined %}
     "description": "{{ workflow_template.description | default('') }}",
+{% endif %}
+{% if workflow_template.extra_vars is defined %}
     "extra_vars": "{{ workflow_template.extra_vars | default('') }}",
+{% endif %}
     "organization": null,
+{% if workflow_template.allow_simultaneous is defined %}
     "allow_simultaneous": "{{ workflow_template.allow_simultaneous | default(true) }}",
+{% endif %}
+{% if workflow_template.ask_variables_on_launch is defined %}
     "ask_variables_on_launch": {{workflow_template.ask_variables_on_launch | default(false) }},
+{% endif %}
+{% if workflow_template.webhook_service is defined %}
     "webhook_service": "{{ workflow_template.webhook_service | default('') }}"
+{% endif %}
 }


### PR DESCRIPTION

### What does this PR do?
This PR adds minor modifications to two ansible-tower role: 
   - manage-workflow-templates
   - manage-schedules 
 Modifications are made to ensure both of them play together nicely, and one can setup a Tower Schedule for Workflow Template

### How should this be tested?
Run against Ansible Tower

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/infra-ansible
