### PR TITLE
Minor fix for SCM git role

### DIFF
--- a/roles/scm/git/README.md
+++ b/roles/scm/git/README.md
@@ -41,7 +41,7 @@ Example Playbook
 
     - name: "Touch a file inside the repo"
       file:
-        path: "{{ scm_dir }}/hello_worls.txt"
+        path: "{{ scm_dir }}/hello_world.txt"
         state: touch
 
     - name: "Commit changes and push git repository"

--- a/roles/scm/git/defaults/main.yml
+++ b/roles/scm/git/defaults/main.yml
@@ -11,17 +11,25 @@ git:
   message: "Auto-update files"
   remove_local: false
 
+###############
 # Example using HTTP
+###############
+
 #repository:
 #  name: example
 #  url: https://github.com/org/repo.git
 #  branch: main
 #  username: hello
 #  password: password
+#  update_revision: true
 
+###############
 # Example using SSH
+###############
+
 #repository:
 #  name: example
 #  url: ssh://git@github.com/org/repo.git
 #  branch: main
 #  ssh_key: "{{ lookup('file', '/var/home/mahdtech/.ssh/id_ed25519') }}"
+#  update_revision: true

--- a/roles/scm/git/tasks/main.yml
+++ b/roles/scm/git/tasks/main.yml
@@ -13,7 +13,7 @@
         - repository.url is defined
 
 - name: Pre-flight checks (SSH Repo)
-  fail:
+  ansible.builtin.fail:
     msg:
       - "SSH Private key is expected when the URL is of type SSH"
   when:
@@ -21,7 +21,7 @@
     - not repository.ssh_key is defined
 
 - name: Pre-flight checks (HTTP Repo)
-  fail:
+  ansible.builtin.fail:
     msg:
       - "Personal Access Token is expected when the URL is of type HTTP"
   when:
@@ -29,12 +29,12 @@
     - ( not repository.username is defined or not repository.password is defined )
 
 - name: Pre-flight checks (Confused Repo)
-  fail:
+  ansible.builtin.fail:
     msg:
       - "Please provide either;"
-      - "   an SSH key with a url starting with ssh://"
-      - "   or a PAT with a user starting with http://"
-      - "but not both..."
+      - "   an SSH key and a url that starts with ssh://"
+      - "   OR"
+      - "   a PAT with a url that starts with http://"
   when:
     - repository.ssh_key is defined
     - repository.password is defined

--- a/roles/scm/git/tasks/pull.yml
+++ b/roles/scm/git/tasks/pull.yml
@@ -24,9 +24,8 @@
     force: "{{ repository.force | default(omit) }}"
     key_file: "{{ ssh_key | default(omit) }}"
     remote: "{{ repository.remote | default('origin') }}"
-    # Bracket notation used to avoid public method clash
-    update: "{{ repository['update'] | default(omit) }}"
-    version: "{{ repository.version | default('HEAD') }}"
-    accept_hostkey: "{{ repository.accept_hostkey | default(omit) }}"
+    update: "{{ repository.update_revision | default(omit) }}"
+    version: "{{ repository.version | default(omit) }}"
+    accept_hostkey: "{{ repository.accept_hostkey | default('yes') }}"
   when:
     - scm_dir is defined


### PR DESCRIPTION
### What does this PR do?

Adds the following minor fixes to the scm git role

- Clear up message confusion
- Default to auto accept host key
- Keep newer Ansible linter plugin happy
- Use non-reserved keyword as even square bracket notation fails
- Correct typo in README.md

### How should this be tested?

Execute role

### Is there a relevant Issue open for this?

None

### Other Relevant info, PRs, etc

This is a fix that adds to #634

### People to notify

cc: @redhat-cop/infra-ansible
