### PR TITLE
Add a pause after Tower deployment is completed on OCP

### DIFF
--- a/roles/ansible/tower/config-ansible-tower-ocp/README.md
+++ b/roles/ansible/tower/config-ansible-tower-ocp/README.md
@@ -24,6 +24,7 @@ The variables used to install Ansible Tower on OpenShift are outlined in the tab
 |ansible_tower_download_url|URL of Ansible Tower installer artifact repository|no|`https://releases.ansible.com/ansible-tower/setup_openshift/ansible-tower-openshift-setup-{{ ansible_tower_version }}.tar.gz`|
 |ansible_tower_version|Version of Ansible Tower Openshift installer|no|latest|
 |ansible_tower_remote_src|Is the Ansible Tower installer fetched from a remote source|no|true|
+|ansible_tower_postdeployment_pause| Time in minutes for which role will wait for Tower to settle down after deployment|no|5|
 |ansible_tower.install.openshift.host|OpenShift API url|no|CRC on local host|
 |ansible_tower.install.openshift.project|Project where to deploy Tower|no|'tower'|
 |ansible_tower.install.openshift.user|User to login into openshift|no|"test"|

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -51,5 +51,5 @@
 
 - name: "Pausing for 5 minutes to let Tower settle down"
   pause:
-    minutes: 5
+    minutes: "{{ ansible_tower_postdeployment_pause | default(5) }}"
 

--- a/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
+++ b/roles/ansible/tower/config-ansible-tower-ocp/tasks/deploy_tower.yml
@@ -49,3 +49,7 @@
   args:
     chdir: "{{ ansible_tower_dir }}"
 
+- name: "Pausing for 5 minutes to let Tower settle down"
+  pause:
+    minutes: 5
+


### PR DESCRIPTION
### What does this PR do?
This PR adds a sleep after Tower on OCP is deployed, so it has some time to settle down before the configuration is applied

### How should this be tested?
Execute the role

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
