### PR TITLE
Fix Ansible manage inventories role

### DIFF
--- a/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
+++ b/roles/ansible/tower/manage-inventories/tasks/process-inventory.yml
@@ -30,7 +30,7 @@
       Accept: "application/json"
     validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 200,201
-  register: inventory_output
+  register: inventory_output_create
   when:
     - (inv_id is not defined) or (inv_id | length == 0)
 
@@ -48,17 +48,17 @@
       Accept: "application/json"
     validate_certs: "{{ ansible_tower.validate_certs | default(validate_tower_certs) | default(true) }}"
     status_code: 200,201
-  register: inventory_output
+  register: inventory_output_update
   when:
     - inv_id is defined
     - inv_id | length > 0
 
 - name: 'Get inventory id from the loaded inventory'
   set_fact:
-    inv_id: "{{ inventory_output.json.id }}"
+    inv_id: "{{ inventory_output_create.json.id }}"
   when:
     - (inv_id is not defined) or (inv_id | length == 0)
-    - inventory_output is succeeded
+    - inventory_output_create is succeeded
 
 - name: "Process the inventory host entries"
   include_tasks: process-host.yml


### PR DESCRIPTION
### What does this PR do?

Fixes a regression introduced in # where the first time an inventory is created the id is unknown by using a different register value for create vs update.

### How should this be tested?

Execute the role against a blank tower install and a tower with existing inventories.

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc.

N/A

### People to notify

cc: @redhat-cop/infra-ansible
