### PR TITLE
Tuning notification playbooks to allow for single user notification

### DIFF
--- a/playbooks/notifications/email-notify-single-user.yml
+++ b/playbooks/notifications/email-notify-single-user.yml
@@ -1,15 +1,8 @@
 ---
 
-- include_vars:
-    file: "{{ email_content_file }}"
-  when:
-    - email_content_file is defined
-- set_fact:
-    markdown_content: "{{ body }}"
-- include_role:
-    name: notifications/md-to-html
-- set_fact:
-    mail: "{{ mail | combine( {'subject': title, 'body': md_to_html.html_body_message, 'to': email_to} ) }}"
-- include_role:
-    name: notifications/send-email
+- name: "Send HTML e-mail message to a single user"
+  hosts: mail-host
+  gather_facts: no
+  tasks:
+  - include_tasks: email-notify-tasks.yml
 

--- a/playbooks/notifications/email-notify-tasks.yml
+++ b/playbooks/notifications/email-notify-tasks.yml
@@ -1,0 +1,15 @@
+---
+
+- include_vars:
+    file: "{{ email_content_file }}"
+  when:
+    - email_content_file is defined
+- set_fact:
+    markdown_content: "{{ body }}"
+- include_role:
+    name: notifications/md-to-html
+- set_fact:
+    mail: "{{ mail | combine( {'subject': title, 'body': md_to_html.html_body_message, 'to': email_to} ) }}"
+- include_role:
+    name: notifications/send-email
+

--- a/playbooks/notifications/email-notify-users.yml
+++ b/playbooks/notifications/email-notify-users.yml
@@ -4,7 +4,7 @@
   hosts: mail-host
   gather_facts: no
   tasks:
-  - include_tasks: email-notify-single-user.yml
+  - include_tasks: email-notify-tasks.yml
     vars:
       first_name: "{{ item.first_name }}"
       user_name: "{{ item.user_name }}"


### PR DESCRIPTION
### What does this PR do?
This PR makes it possible to send a generic message to any user by converting the tasks file to a playbook and moving the tasks to a new file.

### How should this be tested?
Use the `email-notify-single-user.yml` playbook

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
