### PR TITLE
Updating password role to limit the special characters used in passwords

### DIFF
--- a/roles/identity-management/manage-user-password/defaults/main.yml
+++ b/roles/identity-management/manage-user-password/defaults/main.yml
@@ -13,5 +13,6 @@ generate_password_length: '16'
 # - whitespace
 #
 # ... or just a string of characters to use
-# 
+#
 generate_password_char_sets: 'ascii_letters,digits,!#%*+,-./:=?^_|'
+

--- a/roles/identity-management/manage-user-password/defaults/main.yml
+++ b/roles/identity-management/manage-user-password/defaults/main.yml
@@ -11,4 +11,7 @@ generate_password_length: '16'
 # - printable
 # - punctuation
 # - whitespace
-generate_password_char_sets: 'ascii_letters,digits,punctuation'
+#
+# ... or just a string of characters to use
+# 
+generate_password_char_sets: 'ascii_letters,digits,!#%*+,-./:=?^_|'


### PR DESCRIPTION
### What does this PR do?
The use of `punctuation` in passwords results in in too many undesirable special characters. This PR changes it to a limited set: `!#%*+,-./:=?^_|`

### How should this be tested?
Use the role to generate a password - observe that the special characters used are within the defined set 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
