### PR TITLE
Some symbols can be treated as formatting and missed by users

### DIFF
--- a/roles/identity-management/manage-user-password/defaults/main.yml
+++ b/roles/identity-management/manage-user-password/defaults/main.yml
@@ -14,5 +14,5 @@ generate_password_length: '16'
 #
 # ... or just a string of characters to use
 #
-generate_password_char_sets: 'ascii_letters,digits,!#%*+,-./:=?^_|'
+generate_password_char_sets: 'ascii_letters,digits,!#%+,-./:=?_|'
 


### PR DESCRIPTION
### What does this PR do?
Some symbols (e.g. * or ^) can be treated as formatting symbols by the systems where users will check generated passwords, for example gmail Web UI. In this case these symbols are not seen by users and passwords will be entered incorrectly.


### People to notify
cc: @redhat-cop/infra-ansible
