### PR TITLE
Adding OSP role to manage Swift objects and containers

### DIFF
--- a/playbooks/osp/manage-object-container.yml
+++ b/playbooks/osp/manage-object-container.yml
@@ -1,0 +1,8 @@
+---
+
+# See the roles README for detailed info on inventory requirements.
+# https://github.com/redhat-cop/infra-ansible/blob/main/roles/osp/admin-object-container/README.md
+
+- hosts: osp-provisioner
+  roles:
+  - osp/admin-object-container

--- a/roles/osp/admin-object-container/README.md
+++ b/roles/osp/admin-object-container/README.md
@@ -1,0 +1,63 @@
+Role Name
+=========
+
+This role allow users to automate the creation of their OpenStack Platform (OSP) Object Containers (swift) with content
+
+Requirements
+------------
+
+1. A valid OpenStack RC file, with the proper access rights to an OpenStack tenant, needs to be sourced before using this role.
+1. The `openstack` python shade packages to allow for interactions with the platform.
+
+Role Variables
+--------------
+
+See `Example Inventory` below for more specific details. The following variable needs to be defined:
+
+- `osp_container_objects`: A list of files to create in object container(s)
+
+
+Dependencies
+------------
+
+* A valid OSP tenant with the proper configuration 
+  * User or service account used to manage content needs to have the 'swiftoperator' role assigned
+
+
+Example Playbook
+----------------
+
+```
+- hosts: servers
+  roles:
+  - role: osp/admin-object-container
+```
+
+**Note:** Make sure to source the OpenStack RC file (with proper access rights) before running this playbook/role.
+
+Example Inventory
+----------------
+
+```
+osp_container_objects:
+  - name: "test-file-1.txt"
+    container: "my-test-container
+    container_access: "public"
+    filename: "{{ inventory_dir }}/../files/test-file-1.txt"
+  - name: "test-file-2.txt"
+    container: "my-test-container
+    container_access: "public"
+    filename: "{{ inventory_dir }}/../files/test-file-2.txt"
+```
+
+
+License
+-------
+
+Apache License 2.0
+
+
+Author Information
+------------------
+
+Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/osp/admin-object-container/tasks/main.yml
+++ b/roles/osp/admin-object-container/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+
+- name: Manage OpenStack Container Objects
+  os_object:
+    cloud: "{{ item.cloud | default(osp_default_cloud) | default(omit) }}"
+    state: "{{ item.state | default(osp_resource_state) | default('present') }}"
+    name: "{{ item.name }}"
+    container: "{{ item.container }}"
+    container_access: "{{ item.container_access | default(omit) }}"
+    endpoint_type: "{{ item.endpoint_type | default(omit) }}"
+    filename: "{{ item.filename | default(omit) }}"
+  register: os_container_objects
+  with_items:
+  - "{{ osp_container_objects | default([]) }}"
+


### PR DESCRIPTION
### What does this PR do?
This role - and playbook - allows for management of Swift Object + Container. This allows for a list of files to be defined to be uploaded to a Swift Container. The container will be created and file added. If the "state" is set to "absent" it will remove the file. (the container is not removed per this version, but will be functionality available in future releases). 

### How should this be tested?
Define an inventory per the README with content to be uploaded to swift container.
Make sure to run the playbook as a user that has `swiftoperator` set as a role for the target project in OSP
Observe that the Swift Container and corresponding object has been created. 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
