### PR TITLE
Set infra-ansible Dockerfile to use specific base image

### DIFF
--- a/images/infra-ansible/Dockerfile
+++ b/images/infra-ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora
+FROM registry.fedoraproject.org/fedora:34
 
 ENV HELM_VERSION=latest \
     KUSTOMIZE_VERSION=v3.5.4


### PR DESCRIPTION
### What does this PR do?
This PR modifies Infra-Ansible Dockerfile so that it uses specific base image tag instead of `latest`

### How should this be tested?
build Infra-Ansible docker image.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A


### People to notify
cc: @redhat-cop/infra-ansible
