### PR TITLE
User Management: Improve how password and notification flags are handled

### DIFF
--- a/roles/identity-management/manage-aws-identities/filter_plugins/set-aws-user-flags.py
+++ b/roles/identity-management/manage-aws-identities/filter_plugins/set-aws-user-flags.py
@@ -6,13 +6,13 @@ def set_aws_user_flags(entry):
     else:
         flag_state = False
 
-    if 'generate_password' not in entry:
-        entry['generate_password'] = flag_state 
+    if 'generate_password' not in entry['user_data'].keys():
+        entry['user_data']['generate_password'] = flag_state 
 
-    if 'notify_user' not in entry:
-        entry['notify_user'] = flag_state 
+    if 'notify_user' not in entry['user_data'].keys():
+        entry['user_data']['notify_user'] = flag_state 
 
-    return entry
+    return entry['user_data']
 
 class FilterModule(object):
     def filters(self):

--- a/roles/identity-management/manage-aws-identities/filter_plugins/set-aws-user-flags.py
+++ b/roles/identity-management/manage-aws-identities/filter_plugins/set-aws-user-flags.py
@@ -1,16 +1,18 @@
+
 def set_aws_user_flags(entry):
 
-    data = {
-        'generate_password': False,
-        'notify_user': False
-    }
-
     if 'iam_user' in entry.keys() and entry['changed']:
-        data['generate_password'] = True
-        data['notify_user'] = True
+        flag_state = True
+    else:
+        flag_state = False
 
-    return data
+    if 'generate_password' not in entry:
+        entry['generate_password'] = flag_state 
 
+    if 'notify_user' not in entry:
+        entry['notify_user'] = flag_state 
+
+    return entry
 
 class FilterModule(object):
     def filters(self):

--- a/roles/identity-management/manage-aws-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/create_users.yml
@@ -37,7 +37,7 @@
 
     - name: "Create password generation dataset"
       set_fact:
-        list_of_users: "{{ list_of_users + [ aws_data.user_data|combine(aws_data|set_aws_user_flags, {'aws_profile': identities.profile_name|default('')}) ] }}"
+        list_of_users: "{{ list_of_users + [ aws_data.user_data|set_aws_user_flags|combine({'aws_profile': identities.profile_name|default('')}) ] }}"
       with_items:
         - "{{ aws_user_list.results }}"
       loop_control:

--- a/roles/identity-management/manage-aws-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-aws-identities/tasks/create_users.yml
@@ -37,7 +37,7 @@
 
     - name: "Create password generation dataset"
       set_fact:
-        list_of_users: "{{ list_of_users + [ aws_data.user_data|set_aws_user_flags|combine({'aws_profile': identities.profile_name|default('')}) ] }}"
+        list_of_users: "{{ list_of_users + [ aws_data|set_aws_user_flags|combine({'aws_profile': identities.profile_name|default('')}) ] }}"
       with_items:
         - "{{ aws_user_list.results }}"
       loop_control:

--- a/roles/identity-management/manage-idm-identities/filter_plugins/set-user-flags.py
+++ b/roles/identity-management/manage-idm-identities/filter_plugins/set-user-flags.py
@@ -1,18 +1,18 @@
 
 def set_user_flags(entry):
 
-    if 'has_password' in entry.keys() and entry['has_password'] == False:
+    if 'user' in entry.keys() and 'has_password' in entry['user'].keys() and entry['user']['has_password'] == False:
         flag_state = True
     else:
         flag_state = False
 
-    if 'generate_password' not in entry:
-        entry['generate_password'] = flag_state 
+    if 'generate_password' not in entry['user_data'].keys():
+        entry['user_data']['generate_password'] = flag_state 
 
-    if 'notify_user' not in entry:
-        entry['notify_user'] = flag_state 
+    if 'notify_user' not in entry['user_data'].keys():
+        entry['user_data']['notify_user'] = flag_state 
 
-    return entry
+    return entry['user_data']
 
 class FilterModule(object):
     def filters(self):

--- a/roles/identity-management/manage-idm-identities/filter_plugins/set-user-flags.py
+++ b/roles/identity-management/manage-idm-identities/filter_plugins/set-user-flags.py
@@ -1,16 +1,18 @@
+
 def set_user_flags(entry):
 
-    data = {
-        'generate_password': False,
-        'notify_user': False
-    }
+    if 'has_password' in entry.keys() and entry['has_password'] == False:
+        flag_state = True
+    else:
+        flag_state = False
 
-    if 'user' in entry.keys() and 'has_password' in entry['user'].keys() and entry['user']['has_password'] == False:
-        data['generate_password'] = True
-        data['notify_user'] = True
+    if 'generate_password' not in entry:
+        entry['generate_password'] = flag_state 
 
-    return data
+    if 'notify_user' not in entry:
+        entry['notify_user'] = flag_state 
 
+    return entry
 
 class FilterModule(object):
     def filters(self):

--- a/roles/identity-management/manage-idm-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-idm-identities/tasks/create_users.yml
@@ -31,7 +31,7 @@
 
     - name: "Create password generation dataset"
       set_fact:
-        list_of_users: "{{ list_of_users + [ idm_data.user_data|combine(idm_data|set_user_flags) ] }}"
+        list_of_users: "{{ list_of_users + [ idm_data.user_data|set_user_flags ] }}"
       with_items:
         - "{{ idm_user_list.results }}"
       loop_control:

--- a/roles/identity-management/manage-idm-identities/tasks/create_users.yml
+++ b/roles/identity-management/manage-idm-identities/tasks/create_users.yml
@@ -31,7 +31,7 @@
 
     - name: "Create password generation dataset"
       set_fact:
-        list_of_users: "{{ list_of_users + [ idm_data.user_data|set_user_flags ] }}"
+        list_of_users: "{{ list_of_users + [ idm_data|set_user_flags ] }}"
       with_items:
         - "{{ idm_user_list.results }}"
       loop_control:


### PR DESCRIPTION
### What does this PR do?
This PR improves the flag handling. If the flags for a user have already been set, the filter plugins won't set them again. 

### How should this be tested?
Run with a list of users with the `generate_password` and/or `notify_user` set to `False` - observe how the user don't get a password generated or doesn't get notified 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
