### PR TITLE
Fix IdM on OSP provisioning

### DIFF
--- a/inventory/idm-server/group_vars/all.yml
+++ b/inventory/idm-server/group_vars/all.yml
@@ -30,5 +30,5 @@ dns_data:
           entries:
             - type: PTR
               record: "{{ hostvars['idm.subdomain']['openstack']['private_v4_ptr'] }}"
-              value: "idm.subdomain.my_dns_zone
+              value: "idm.subdomain.my_dns_zone"
 

--- a/inventory/idm-server/group_vars/all.yml
+++ b/inventory/idm-server/group_vars/all.yml
@@ -2,3 +2,33 @@
 
 pkg_update: true
 hosting_infrastructure: openstack
+
+dns_data:
+  views:
+    - name: private
+      zones:
+        - dns_domain: "my_dns_zone"
+          state: present
+          named: True
+          nsupdate:
+            - server: "dns_server_ip"
+              key_name: "dns_zone_key_name"
+              key_secret: 'key_secret'
+              key_algorithm: 'hmac-sha256'
+          entries:
+            - type: A
+              record: "idm.subdomain"
+              value: "{{ hostvars['idm.subdomain']['openstack']['private_v4'] }}"
+        - dns_domain: "my_reverse_zone"
+          state: present
+          named: True
+          nsupdate:
+            - server: "dns_server_ip"
+              key_name: "reverse_key_name"
+              key_secret: 'key_secret'
+              key_algorithm: 'hmac-sha256'
+          entries:
+            - type: PTR
+              record: "{{ hostvars['idm.subdomain']['openstack']['private_v4_ptr'] }}"
+              value: "idm.subdomain.my_dns_zone
+

--- a/inventory/idm-server/group_vars/idm-server.yml
+++ b/inventory/idm-server/group_vars/idm-server.yml
@@ -16,15 +16,3 @@ idm_realm: EXAMPLE.COM
 idm_dm_password: my_dm_password
 idm_admin_password: my_admin_password
 
-dns_records:
-  server: "dns_server_ip"
-  reverse:
-    zone: "my_reverse_zone"
-    key_name: 'reverse_key_name'
-    key_secret: 'key_secret'
-    key_algorithm: 'hmac-sha256'
-  forward:
-    zone: "my_forward_zone"
-    key_name: 'forward_key_name'
-    key_secret: 'my_key_secret'
-    key_algorithm: 'hmac-sha256'

--- a/inventory/idm-server/hosts
+++ b/inventory/idm-server/hosts
@@ -8,7 +8,7 @@ localhost
 [idm-server]
 idm.example.com
 
-[dns-server]
+[dns-records-manage-host]
 localhost
 
 [osp_instances:children]

--- a/playbooks/provision-idm-server/setup-idm-dns.yml
+++ b/playbooks/provision-idm-server/setup-idm-dns.yml
@@ -1,46 +1,14 @@
 ---
 
+# Note: The following play only supports PTR records of a /24 subnet
 - hosts: idm-server
   tasks:
-    - name: Set required ip address for forward dns
+    - name: "Set required ip address for PTR dns record"
       set_fact:
-        dns_records: "{{ dns_records|combine({
-          'view': inventory_hostname.split('.')[1:-1],
-          'forward': { 'ip': openstack.private_v4,
-                        'hostname': inventory_hostname.split('.')[0]  },
-          'reverse': { 'hostname': openstack.private_v4.split('.')[-1],
-                        'target': inventory_hostname + '.'  }
-        }, recursive=True) }}"
+        openstack: "{{ openstack | combine({'private_v4_ptr': openstack.private_v4.split('.')[-1]}) }}"
       when:
         - hosting_infrastructure == 'openstack'
 
-- name: 'Copying dns_records from idm-server hosts'
-  hosts: dns-server
-  tasks:
-    - set_fact:
-        dns_records: "{{ hostvars[groups['idm-server'][0]]['dns_records'] }}"
-
-- name: Add DNS records for IdM
+- name: "Add DNS records for IdM"
   import_playbook: ../update-dns-records.yml
-  vars:
-    dns_records_add:
-      - view: "{{ dns_records.view }}"
-        zone: "{{ dns_records.reverse.zone }}"
-        server: "{{ dns_records.server }}"
-        key_name: "{{ dns_records.reverse.key_name }}"
-        key_secret: "{{ dns_records.reverse.key_secret }}"
-        key_algorithm: "{{ dns_records.reverse.key_algorithm }}"
-        entries:
-          - type: ptr
-            hostname: "{{ dns_records.reverse.hostname }}"
-            ip: "{{ dns_records.reverse.target }}"
-      - view: "{{ dns_records.view }}"
-        zone: "{{ dns_records.forward.zone }}"
-        server: "{{ dns_records.server }}"
-        key_name: "{{ dns_records.forward.key_name }}"
-        key_secret: "{{ dns_records.forward.key_secret }}"
-        key_algorithm: "{{ dns_records.forward.key_algorithm }}"
-        entries:
-          - type: A
-            hostname: "{{ dns_records.forward.hostname }}"
-            ip: "{{ dns_records.forward.ip }}"
+


### PR DESCRIPTION
### What does this PR do?
The DNS handling within this repo has changed, but the IdM playbook didn't follow. This PR fixes this to allow for successful IdM provisioning again. 

### How should this be tested?
Use the IdM inventory (with necessary tweaks to fit your target environment) to automatically spin up an IdM instance on RHEL7

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
