### PR TITLE
Add support for custom packages list in 'manage-haproxy' role

### DIFF
--- a/roles/load-balancers/manage-haproxy/defaults/main.yml
+++ b/roles/load-balancers/manage-haproxy/defaults/main.yml
@@ -2,3 +2,11 @@
 
 temp_new_file: '/etc/haproxy/haproxy.cfg.new'
 lb_https_backends: {}
+lb_install_packages:
+   - haproxy
+   - openssl-devel
+   - firewalld
+   - python3-firewall
+   - libsemanage-python
+   - policycoreutils-python
+

--- a/roles/load-balancers/manage-haproxy/tasks/install.yml
+++ b/roles/load-balancers/manage-haproxy/tasks/install.yml
@@ -6,13 +6,7 @@
       package:
         name: '{{ item }}'
         state: installed
-      with_items:
-        - haproxy
-        - openssl-devel
-        - firewalld
-        - python3-firewall
-        - libsemanage-python
-        - policycoreutils-python
+      loop: '{{ lb_install_packages|flatten(levels=-1) }}'
       notify: 'enable and start service(s)'
 
     - name: 'Start firewalld'


### PR DESCRIPTION
### What does this PR do?
This PR removes hard-coded list of packages to be installed on LB, in favor of configurable list.
Default list holds packages list valid for Centos7

### How should this be tested?
Run the role with supplied defaults 

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
