### PR TITLE
Fixing list_of_mail_to list generation

### DIFF
--- a/playbooks/notifications/email-notify-list-of-users.yml
+++ b/playbooks/notifications/email-notify-list-of-users.yml
@@ -3,6 +3,9 @@
 - name: "Send HTML e-mail message (based on MD) to a list of users"
   hosts: mail-host
   gather_facts: no
+  vars:
+    list_of_mail_to: []
+
   tasks:
     - include_vars:
         file: "{{ email_content_file }}"
@@ -14,9 +17,11 @@
         markdown_content: "{{ body }}"
     - set_fact:
         mail: "{{ mail | combine({ 'subject': title, 'body': md_to_html.html_body_message }) }}"
+
     - set_fact:
-        list_of_mail_to: "{{ list_of_mail_to | default([]) }} + [ '{{ item.email }}' ]"
-      with_items:
-        - "{{ list_of_users }}"
+        list_of_mail_to: "{{ list_of_mail_to | d([]) + [ item.email ] }}"
+      loop: "{{ list_of_users }}"
+      when: list_of_users is defined
+
     - include_role:
         name: notifications/send-email


### PR DESCRIPTION
### What does this PR do?
The `list_of_mail_to list` (which is used for the SMTP `TO:` field) is generated as follow, so SMTP servers which are strictly follows RFC returning errors.
``` 
"to": "[] + [ 'name@domain.com' ]",
```
This PR updating list_of_mail_to generation, so the final result looks like:
``` 
"to": [
     "name@domain.com",
     "first.last@domain.com"
  ]
```

### How should this be tested?
This PR was tested by sending emails using the `email-notify-list-of-users.yml` playbook.

### People to notify
cc: @redhat-cop/infra-ansible
