### PR TITLE
Added support for paged quay API requests

### DIFF
--- a/roles/scm/quay/tasks/_api_request.yml
+++ b/roles/scm/quay/tasks/_api_request.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Verify Required API Request Parameters Provided
+  ansible.builtin.assert:
+    that:
+      - api_request_uri | default("", true) | length > 0
+      - api_request_var | default("", true) | length > 0
+    quiet: true
+    fail_msg: Required API Variables Not Provided
+
+- name: "Execute API Request: {{ api_request_uri }}"
+  ansible.builtin.uri:
+    url: "{{ api_request_uri + ((('&' if '?' in api_request_uri else '?')  + 'next_page=' + api_request_next_page| default('', True)) if api_request_next_page is defined else '') }}"
+    validate_certs: "{{ quay_validate_certs }}"
+    status_code: "{{ api_request_status_code | default([200], True)}}"
+    headers:
+      Authorization: "{{ auth_header }}"
+  register: api_request_response
+
+- name: Set API Response Variable
+  ansible.builtin.set_fact:
+    "{{ api_request_var }}": "{{ lookup('ansible.builtin.vars', api_request_var, default=[]) | ansible.builtin.combine(api_request_response, list_merge='append', recursive=true) }}"
+
+- name: "Paginate API Request: {{ api_request_uri }}"
+  ansible.builtin.include_tasks:
+    file: _api_request.yml
+  vars:
+    api_request_next_page: "{{ api_request_response.json['next_page'] }}"
+  when: "'next_page' in api_request_response.json"
+
+- name: Clear Request Variables
+  ansible.builtin.set_fact:
+    api_request_next_page:
+    api_request_status_code:

--- a/roles/scm/quay/tasks/main.yml
+++ b/roles/scm/quay/tasks/main.yml
@@ -1,19 +1,20 @@
 ---
 
+- name: Assert Authorization header has been set
+  ansible.builtin.assert:
+    that:
+      quay_api_token | default("", true) | length > 0
+    fail_msg: "Quay API Token must be specified"
+    quiet: true
+
 - name: Set Authorization Header when specifying API token
-  set_fact:
+  ansible.builtin.set_fact:
     auth_header: "Bearer {{ quay_api_token }}"
   when: (quay_api_token|trim|length) > 0
 
-- name: Assert Authorization header has been set
-  assert:
-    that:
-      (quay_api_token|trim|length) > 0
-    fail_msg: "Quay API Token must be specified"
-
 - name: Manage Organizations
-  include_tasks: manage_organization.yml
+  ansible.builtin.include_tasks: manage_organization.yml
   loop: "{{ orgs | default([]) }}"
   loop_control:
     loop_var: quay_organization
-
+    label: "{{ quay_organization['name'] }}"

--- a/roles/scm/quay/tasks/manage_organization.yml
+++ b/roles/scm/quay/tasks/manage_organization.yml
@@ -1,17 +1,16 @@
 ---
 - name: Check if Organization Exists
-  uri:
-    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
-    validate_certs: "{{ quay_validate_certs }}"
-    status_code:
+  ansible.builtin.include_tasks:
+    file: _api_request.yml
+  vars:
+    api_request_uri: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
+    api_request_var: quay_organization_exists
+    api_request_status_code:
       - 200
       - 404
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: quay_organization_exists
 
-- name: Create Quay Organization
-  uri:
+- name: "Create Quay Organization: {{ quay_organization.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/"
     method: POST
     body:
@@ -24,8 +23,8 @@
       Authorization: "{{ auth_header }}"
   when: quay_organization_exists.status == 404
 
-- name: Update Quay Organization
-  uri:
+- name: "Update Quay Organization: {{ quay_organization.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
     method: PUT
     body:
@@ -38,74 +37,69 @@
       Authorization: "{{ auth_header }}"
   when: quay_organization_exists.status == 200
 
-- name: Get Quay Organization
-  uri:
-    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
-    validate_certs: "{{ quay_validate_certs }}"
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: current_quay_org
+- name: "Get Quay Organization: {{ quay_organization.name }}"
+  ansible.builtin.include_tasks:
+    file: _api_request.yml
+  vars:
+    api_request_uri: "{{ quay_api_base }}/organization/{{ quay_organization.name }}"
+    api_request_var: current_quay_org
 
-- name: List Organization Robots
-  uri:
-    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots"
-    validate_certs: "{{ quay_validate_certs }}"
-    status_code:
-      - 200
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: org_robots
+- name: "List Organization Robots - {{ quay_organization.name }}"
+  ansible.builtin.include_tasks:
+    file: _api_request.yml
+  vars:
+    api_request_uri: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots"
+    api_request_var: org_robots
 
-- name: List Organization Prototypes
-  uri:
-    url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes"
-    validate_certs: "{{ quay_validate_certs }}"
-    status_code:
-      - 200
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: org_prototypes
+- name: "List Organization Prototypes - {{ quay_organization.name }}"
+  ansible.builtin.include_tasks:
+    file: _api_request.yml
+  vars:
+    api_request_uri: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes"
+    api_request_var: org_prototypes
 
-- name: Manage Robots
-  include_tasks: manage_robot.yml
+- name: "Manage Robots - Organization: {{ quay_organization.name }}"
+  ansible.builtin.include_tasks: manage_robot.yml
   loop: "{{ quay_organization.robots | default([]) }}"
   loop_control:
     loop_var: quay_robot
+    label: "{{ quay_robot['name'] }}"
 
-- name: Manage Teams
-  include_tasks: manage_team.yml
+- name: "Manage Teams - Organization: {{ quay_organization.name }}"
+  ansible.builtin.include_tasks: manage_team.yml
   loop: "{{ quay_organization.teams | default([]) }}"
   loop_control:
     loop_var: quay_team
+    label: "{{ quay_team['name'] }}"
 
-- name: Manage Prototypes
-  include_tasks: manage_prototypes.yml
+- name: "Manage Prototypes - Organization: {{ quay_organization.name }}"
+  ansible.builtin.include_tasks: manage_prototypes.yml
   loop: "{{ quay_organization.prototypes | default([]) }}"
   loop_control:
     loop_var: quay_prototype
+    label: "{{ quay_prototype['name'] }}"
 
-- name: List Repositories
-  uri:
-    url: "{{ quay_api_base }}/repository?namespace={{ quay_organization.name }}"
-    validate_certs: "{{ quay_validate_certs }}"
-    body_format: json
-    status_code:
+- name: "List Repositories - Organization: {{ quay_organization.name }}"
+  ansible.builtin.include_tasks:
+    file: _api_request.yml
+  vars:
+    api_request_uri: "{{ quay_api_base }}/repository?namespace={{ quay_organization.name }}"
+    api_request_var: org_repositories
+    api_request_status_code:
       - 200
       - 404
-    headers:
-      Authorization: "{{ auth_header }}"
-  register: org_repositories
 
-- name: Manage Repositories
-  include_tasks: manage_repository.yml
+- name: "Manage Repositories - Organization: {{ quay_organization.name }}"
+  ansible.builtin.include_tasks: manage_repository.yml
   loop: "{{ quay_organization.repos | default([]) }}"
   loop_control:
     loop_var: quay_repository
+    label: "{{ quay_repository['name'] }}"
 
-- name: Prune Organization
+- name: "Prune Organization - Organization: {{ quay_organization.name }}"
   block:
-    - name: Delete Extra Robot Accounts
-      uri:
+    - name: "Delete Extra Robot Accounts - Organization: {{ quay_organization.name }}"
+      ansible.builtin.uri:
         url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots/{{ item.name.split('+')[1] }}"
         method: DELETE
         validate_certs: "{{ quay_validate_certs }}"
@@ -114,15 +108,17 @@
         headers:
           Authorization: "{{ auth_header }}"
       loop: "{{ org_robots.json.robots }}"
+      loop_control:
+        label: "{{ item.name.split('+')[1] }}"
       when: "item.name.split('+')[1] not in quay_organization.robots |  map(attribute='name') | list"
 
     - name: "Warn on Max Repositories Found"
-      debug:
+      ansible.builtin.debug:
         msg: "Warning: Repositories Found: {{ org_repositories.json.repositories | length }}. Purging Only Supported on Organizations with <= 100 Repositories"
       when: org_repositories.json.repositories | length > 100
 
-    - name: Delete Extra Repositories
-      uri:
+    - name: "Delete Extra Repositories - Organization: {{ quay_organization.name }}"
+      ansible.builtin.uri:
         url: "{{ quay_api_base }}/repository/{{ quay_organization.name }}/{{ item.name }}"
         method: DELETE
         validate_certs: "{{ quay_validate_certs }}"
@@ -131,10 +127,12 @@
         headers:
           Authorization: "{{ auth_header }}"
       loop: "{{ org_repositories.json.repositories }}"
+      loop_control:
+        label: "{{ item.name }}"
       when: "item.name not in quay_organization.repos |  map(attribute='name') | list"
 
-    - name: Delete Extra Teams
-      uri:
+    - name: "Delete Extra Teams - Organization: {{ quay_organization.name }}"
+      ansible.builtin.uri:
         url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ item.key }}"
         method: DELETE
         validate_certs: "{{ quay_validate_certs }}"
@@ -143,6 +141,7 @@
         headers:
           Authorization: "{{ auth_header }}"
       loop: "{{ current_quay_org.json.teams | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
       when: "item.key not in quay_organization.teams |  map(attribute='name') | list"
-
   when: quay_prune|bool

--- a/roles/scm/quay/tasks/manage_prototypes.yml
+++ b/roles/scm/quay/tasks/manage_prototypes.yml
@@ -1,6 +1,6 @@
 ---
 - name: Locate Existing Delegate Prototype Matches
-  set_fact:
+  ansible.builtin.set_fact:
     matched_prototypes: "{{ org_prototypes.json.prototypes | \
       selectattr('delegate.is_robot','equalto',true if quay_prototype.delegate.kind == 'robot' else false) | \
       selectattr('delegate.kind','equalto','user' if quay_prototype.delegate.kind != 'team' else quay_prototype.delegate.kind) | \
@@ -8,7 +8,7 @@
       list }}"
 
 - name: Locate Existing Activator Prototype Matches
-  set_fact:
+  ansible.builtin.set_fact:
     matched_prototypes: "{{ matched_prototypes | default([]) | \
       selectattr('activating_user', 'defined') | \
       rejectattr('activating_user', 'none') | \
@@ -19,7 +19,7 @@
   when: "{{ 'activator' in quay_prototype and quay_prototype.activator is not none }}"
 
 - name: Create Base Prototype Fact
-  set_fact:
+  ansible.builtin.set_fact:
     prototype:
       role: "{{ quay_prototype.role }}"
       delegate:
@@ -28,7 +28,7 @@
         is_robot: "{{ true if quay_prototype.delegate.kind == 'robot' else false }}"
 
 - name: Create Prototype Activator Fact
-  set_fact:
+  ansible.builtin.set_fact:
     prototype_assigner:
       role: "{{ quay_prototype.role }}"
       activating_user:
@@ -38,11 +38,11 @@
   when: "{{ 'activator' in quay_prototype and quay_prototype.activator is not none }}"
 
 - name: Create Final Prototype Fact
-  set_fact:
+  ansible.builtin.set_fact:
     prototype: "{{ prototype | combine(prototype_assigner | default({}), recursive=true) }}"
 
-- name: Create Prototype
-  uri:
+- name: "Create Prototype - Organization: {{ quay_organization.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes"
     method: POST
     body: "{{ prototype }}"
@@ -53,8 +53,8 @@
       Authorization: "{{ auth_header }}"
   when: matched_prototypes | length == 0
 
-- name: Update Prototype
-  uri:
+- name: "Update Prototype - Organization: {{ quay_organization.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/prototypes/{{ matched_prototypes[0].id }}"
     method: PUT
     body: "{{ prototype }}"

--- a/roles/scm/quay/tasks/manage_repository.yml
+++ b/roles/scm/quay/tasks/manage_repository.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Set if repository currently exists
-  set_fact:
+  ansible.builtin.set_fact:
     org_repository_exists: "{{ quay_repository.name in org_repositories.json.repositories | map(attribute='name') | list }}"
 
-- name: Create Quay Repository
-  uri:
+- name: "Create Quay Repository - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/repository"
     method: POST
     body:
@@ -21,8 +21,8 @@
       Authorization: "{{ auth_header }}"
   when: not org_repository_exists|bool
 
-- name: Update Quay Repository
-  uri:
+- name: "Update Quay Repository - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}"
     method: PUT
     body:
@@ -38,8 +38,8 @@
       Authorization: "{{ auth_header }}"
   when: org_repository_exists|bool
 
-- name: Manage Permissions
-  uri:
+- name: "Manage Permissions - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/{{ 'team' if 'type' in item and item.type == 'team' else 'user' }}/{{ (quay_repository.namespace | default(quay_organization.name)) + '+' + item.name if item.type == 'robot' else item.name }}"
     method: PUT
     body:
@@ -49,34 +49,34 @@
     status_code: 200
     headers:
       Authorization: "{{ auth_header }}"
+  loop_control:
+    label: "{{ item.name }}"
   loop: "{{ quay_repository.permissions | default([]) }}"
 
-- name: Delete Extra Permissions
+- name: "Delete Extra Permissions - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
   block:
-    - name: List Repository Team Permissions
-      uri:
-        url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/team/"
-        validate_certs: "{{ quay_validate_certs }}"
-        body_format: json
-        status_code:
+    - name: "List Repository Team Permissions - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+      ansible.builtin.include_tasks:
+        file: _api_request.yml
+      vars:
+        api_request_uri: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/team/"
+        api_request_var: org_repositories_permissions_teams
+        api_request_status_code:
           - 200
           - 404
-        headers:
-          Authorization: "{{ auth_header }}"
-      register: org_repositories_permissions_teams
-    - name: List Repository User Permissions
-      uri:
-        url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/user/"
-        validate_certs: "{{ quay_validate_certs }}"
-        body_format: json
-        status_code:
+
+    - name: "List Repository User Permissions - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+      ansible.builtin.include_tasks:
+        file: _api_request.yml
+      vars:
+        api_request_uri: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/user/"
+        api_request_var: org_repositories_permissions_users
+        api_request_status_code:
           - 200
           - 404
-        headers:
-          Authorization: "{{ auth_header }}"
-      register: org_repositories_permissions_users
-    - name: Delete Extra Permissions Team
-      uri:
+
+    - name: "Delete Extra Permissions Team - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+      ansible.builtin.uri:
         url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/team/{{ item.key }}"
         method: DELETE
         validate_certs: "{{ quay_validate_certs }}"
@@ -85,9 +85,12 @@
         headers:
           Authorization: "{{ auth_header }}"
       loop: "{{ (org_repositories_permissions_teams.json.permissions | default({})) | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
       when: (quay_repository.permissions | default([])) | selectattr('name', 'equalto', item.key) | list |  length == 0
-    - name: Delete Extra Permissions User
-      uri:
+
+    - name: "Delete Extra Permissions User - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Repository: {{ quay_repository.name }}"
+      ansible.builtin.uri:
         url: "{{ quay_api_base }}/repository/{{ (quay_repository.namespace | default(quay_organization.name)) }}/{{ quay_repository.name }}/permissions/user/{{ item.value.name }}"
         method: DELETE
         validate_certs: "{{ quay_validate_certs }}"
@@ -96,6 +99,7 @@
         headers:
           Authorization: "{{ auth_header }}"
       loop: "{{ (org_repositories_permissions_users.json.permissions | default({})) | dict2items }}"
+      loop_control:
+        label: "{{ item.value.name }}"
       when: (quay_repository.permissions | default([])) | selectattr('name', 'equalto', item.value.name.split('+')[1] if item.value.is_robot else item.value.name) | list |  length == 0
   when: quay_prune|bool
-

--- a/roles/scm/quay/tasks/manage_robot.yml
+++ b/roles/scm/quay/tasks/manage_robot.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Create/Update Quay Robot
-  uri:
+- name: "Create/Update Quay Robot - Organization: {{ quay_organization.name }} - Robot: {{ quay_robot.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/robots/{{ quay_robot.name }}"
     method: PUT
     body:

--- a/roles/scm/quay/tasks/manage_team.yml
+++ b/roles/scm/quay/tasks/manage_team.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Create/Update Quay Team
-  uri:
+- name: "Create/Update Quay Team - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Team: {{ quay_team.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}"
     method: PUT
     body:
@@ -15,8 +15,8 @@
     headers:
       Authorization: "{{ auth_header }}"
 
-- name: Get Team Members
-  uri:
+- name: "Get Team Members - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Team: {{ quay_team.name }}"
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members"
     validate_certs: "{{ quay_validate_certs }}"
     status_code:
@@ -25,16 +25,17 @@
       Authorization: "{{ auth_header }}"
   register: quay_team_members
 
-- name: Manage Team Members
-  include_tasks: manage_team_members.yml
+- name: "Manage Team Members - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Team: {{ quay_team.name }}"
+  ansible.builtin.include_tasks: manage_team_members.yml
   loop: "{{ quay_team.members | default([]) }}"
   loop_control:
     loop_var: team_member
+    label: "{{ team_member['name'] }}"
 
-- name: Delete Extra Team Members
+- name: "Delete Extra Team Members - Organization: {{ quay_repository.namespace | default(quay_organization.name) }} - Team: {{ quay_team.name }}"
   block:
     - name: Delete Team Member
-      uri:
+      ansible.builtin.uri:
         url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members/{{ quay_organization.name + '+' + item.name if 'type' in item and item.type == 'robot' else item.name }}"
         method: DELETE
         validate_certs: "{{ quay_validate_certs }}"
@@ -43,6 +44,8 @@
         headers:
           Authorization: "{{ auth_header }}"
       loop: "{{ quay_team_members.json.members }}"
+      loop_control:
+        label: "{{ item['name'] }}"
       when: (quay_team.members | default([])) | selectattr('name', 'equalto', item.name.split('+')[1] if item.is_robot else item.name) | list |  length == 0
   when: quay_prune|bool
 

--- a/roles/scm/quay/tasks/manage_team_members.yml
+++ b/roles/scm/quay/tasks/manage_team_members.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Add Team Members
-  uri:
+- name: "Add Team Members - Organization: {{ quay_organization.name }} - Team: {{ quay_team.name }} "
+  ansible.builtin.uri:
     url: "{{ quay_api_base }}/organization/{{ quay_organization.name }}/team/{{ quay_team.name }}/members/{{ quay_organization.name + '+' + team_member.name if 'type' in team_member and team_member.type == 'robot' else team_member.name }}"
     method: PUT
     body:


### PR DESCRIPTION
### What does this PR do?
Added support for paging requests for Quay role

### How should this be tested?
Create a resource (like repositories with more than 100 objects similar to the following

```yaml
orgs:
  - name: redhat-cop
    repos:
      - name: repo1
        visibility: public
      - name: repo2
        visibility: public
      - name: repo3
        visibility: public
...
```

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/infra-ansible
